### PR TITLE
Removed unnecessary dispatch and managed object context references

### DIFF
--- a/PodcastsTableViewController.swift
+++ b/PodcastsTableViewController.swift
@@ -18,7 +18,7 @@ class PodcastsTableViewController: UITableViewController {
     var podcastArray = [Podcast]()
     
     func loadData() {
-        podcastArray = CoreDataHelper.sharedInstance.fetchEntities("Podcast", managedObjectContext: Constants.moc, predicate: nil) as! [Podcast]
+        podcastArray = CoreDataHelper.sharedInstance.fetchEntities("Podcast", predicate: nil) as! [Podcast]
         podcastArray.sortInPlace{ $0.title.removeArticles() < $1.title.removeArticles() }
         
         self.tableView.reloadData()

--- a/podverse.xcodeproj/project.pbxproj
+++ b/podverse.xcodeproj/project.pbxproj
@@ -152,13 +152,13 @@
 		813FC80F1B5CA992006248BC /* PVSubscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVSubscriber.swift; sourceTree = "<group>"; };
 		815A2E301B50C099002A21A7 /* FindTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindTableViewController.swift; sourceTree = "<group>"; };
 		815A2E321B50D002002A21A7 /* FindSearchTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindSearchTableViewCell.swift; sourceTree = "<group>"; };
-		815A2E361B50D855002A21A7 /* FindSearchTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindSearchTableViewController.swift; sourceTree = "<group>"; };
+		815A2E361B50D855002A21A7 /* FindSearchTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = FindSearchTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		815A2E3A1B522467002A21A7 /* SearchResultPodcast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResultPodcast.swift; sourceTree = "<group>"; };
 		81623C281B35D3A100E906FE /* PVDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVDownloader.swift; sourceTree = "<group>"; };
 		817C54071B4B6976007258F8 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		818615901B1E84CE006C9731 /* podverse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = podverse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		818615941B1E84CE006C9731 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		818615951B1E84CE006C9731 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		818615951B1E84CE006C9731 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AppDelegate.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		818615981B1E84CE006C9731 /* podverse.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = podverse.xcdatamodel; sourceTree = "<group>"; };
 		8186159D1B1E84CF006C9731 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8186159F1B1E84CF006C9731 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -167,9 +167,9 @@
 		818615AD1B1E84CF006C9731 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		818615AE1B1E84CF006C9731 /* podverseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = podverseTests.swift; sourceTree = "<group>"; };
 		818615B81B1E85F6006C9731 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
-		818615BF1B1E950D006C9731 /* CoreDataHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataHelper.swift; sourceTree = "<group>"; };
+		818615BF1B1E950D006C9731 /* CoreDataHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CoreDataHelper.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		818615CB1B1EB10E006C9731 /* EpisodesTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpisodesTableViewController.swift; sourceTree = "<group>"; };
-		818615CD1B1EB12C006C9731 /* PodcastsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PodcastsTableViewController.swift; path = ../PodcastsTableViewController.swift; sourceTree = "<group>"; };
+		818615CD1B1EB12C006C9731 /* PodcastsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = PodcastsTableViewController.swift; path = ../PodcastsTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		818615CF1B1EB144006C9731 /* ClipsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipsTableViewController.swift; sourceTree = "<group>"; };
 		818615D11B1EB206006C9731 /* MediaPlayerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPlayerViewController.swift; sourceTree = "<group>"; };
 		81A3B5151B3A60F5007D9A96 /* DownloadsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadsTableViewController.swift; sourceTree = "<group>"; };
@@ -181,7 +181,7 @@
 		81DDBE5C1B24AC8100EF3B9C /* PodcastsTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodcastsTableCell.swift; sourceTree = "<group>"; };
 		81DDBE5E1B24BAF300EF3B9C /* EpisodesTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpisodesTableCell.swift; sourceTree = "<group>"; };
 		81DDBE621B253C9200EF3B9C /* ClipsTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipsTableCell.swift; sourceTree = "<group>"; };
-		81E3578D1B21619F00D67634 /* PVFeedParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVFeedParser.swift; sourceTree = "<group>"; };
+		81E3578D1B21619F00D67634 /* PVFeedParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PVFeedParser.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		81E3578F1B21624500D67634 /* PVUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVUtility.swift; sourceTree = "<group>"; };
 		81E4FE661B2E0C6A00A10A77 /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
 		EF3799D11BD4981E00211419 /* CustomFeedParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomFeedParser.swift; sourceTree = "<group>"; };
@@ -195,7 +195,7 @@
 		EF59CEC81BD07AB6002D9DDF /* NSDate+FeedsDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+FeedsDate.swift"; sourceTree = "<group>"; };
 		EF59CEC91BD07AB6002D9DDF /* String+RemoveHTMLCharacters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+RemoveHTMLCharacters.swift"; sourceTree = "<group>"; };
 		EF70B0761C574BC800234FF2 /* DownloadingEpisodesList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadingEpisodesList.swift; sourceTree = "<group>"; };
-		EFB3249D1BE59127000936B6 /* PVClipperAddInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVClipperAddInfoViewController.swift; sourceTree = "<group>"; };
+		EFB3249D1BE59127000936B6 /* PVClipperAddInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PVClipperAddInfoViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		EFB3249F1BE5913A000936B6 /* PVClipperConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVClipperConfirmationViewController.swift; sourceTree = "<group>"; };
 		EFD1D4E51C3106FA00666912 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		EFD1D4E61C3106FB00666912 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };

--- a/podverse/AppDelegate.swift
+++ b/podverse/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func refreshPodcastFeeds () {
-        let podcastArray = CoreDataHelper.sharedInstance.fetchEntities("Podcast", managedObjectContext: Constants.moc, predicate: nil) as! [Podcast]
+        let podcastArray = CoreDataHelper.sharedInstance.fetchEntities("Podcast", predicate: nil) as! [Podcast]
         for var i = 0; i < podcastArray.count; i++ {
             let feedURL = NSURL(string: podcastArray[i].feedURL)
             
@@ -80,7 +80,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         playCommand.addTarget(self, action: "playOrPauseEvent")
         
         // TODO: Currently we are setting taskIdentifier values = nil on app launch. This will probably need to change once we add crash handling for resuming downloads
-        let episodeArray = CoreDataHelper.sharedInstance.fetchEntities("Episode", managedObjectContext: Constants.moc, predicate: nil) as! [Episode]
+        let episodeArray = CoreDataHelper.sharedInstance.fetchEntities("Episode", predicate: nil) as! [Episode]
         for episode in episodeArray {
             episode.taskIdentifier = nil
         }
@@ -136,7 +136,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             PVMediaPlayer.sharedInstance.saveCurrentTimeAsPlaybackPosition()
         }
         
-        CoreDataHelper.saveCoreData(nil)
+        CoreDataHelper.sharedInstance.saveCoreData(nil)
     }
 }
 

--- a/podverse/Constants.swift
+++ b/podverse/Constants.swift
@@ -16,8 +16,6 @@ struct Constants {
 
     static let kNowPlayingTimeHasChanged = "nowPlayingTimeHasChanged"
     
-    static let moc = CoreDataHelper.sharedInstance.moc
-
     static let saveQueue = dispatch_queue_create("MOC_SERIAL_SAVE_QUEUE", DISPATCH_QUEUE_SERIAL)
     
     static let feedParsingQueue = dispatch_queue_create("FEED_PARSER_QUEUE", DISPATCH_QUEUE_SERIAL);

--- a/podverse/FindSearchTableViewController.swift
+++ b/podverse/FindSearchTableViewController.swift
@@ -66,7 +66,7 @@ class FindSearchTableViewController: UIViewController, UITableViewDataSource, UI
                             	})
                             } else {
                                 // Get all podcasts in Core Data to use to determine if you're already subscribed to a search result podcast
-                                let allSubscribedPodcasts = CoreDataHelper.sharedInstance.fetchEntities("Podcast", managedObjectContext: Constants.moc, predicate: nil) as! [Podcast]
+                                let allSubscribedPodcasts = CoreDataHelper.sharedInstance.fetchEntities("Podcast", predicate: nil) as! [Podcast]
                                 
                                 for (var i = 0; i < results.count; i++) {
                                     

--- a/podverse/PVClipperAddInfoViewController.swift
+++ b/podverse/PVClipperAddInfoViewController.swift
@@ -67,7 +67,7 @@ class PVClipperAddInfoViewController: UIViewController {
     
     func saveClipWithTitle(clipTitle:String) {
         if clip == nil {
-            clip = (CoreDataHelper.sharedInstance.insertManagedObject("Clip", managedObjectContext: Constants.moc) as! Clip)
+            clip = (CoreDataHelper.sharedInstance.insertManagedObject("Clip") as! Clip)
             clip?.episode = episode
         }
         
@@ -99,13 +99,13 @@ class PVClipperAddInfoViewController: UIViewController {
             saveClip(unwrappedClip)
         }
         
-        CoreDataHelper.saveCoreData(nil)
+        CoreDataHelper.sharedInstance.saveCoreData(nil)
     }
     
     final private func saveClip(clip:Clip) {
         let saveClipWS = SaveClipToServer(clip: clip, completionBlock: { (response) -> Void in
             self.clip?.clipUrl = response["clipUri"] as? String
-            CoreDataHelper.saveCoreData(nil)
+            CoreDataHelper.sharedInstance.saveCoreData(nil)
             
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 let alert = UIAlertController(title: "Clip saved with URL:", message: self.clip?.clipUrl, preferredStyle: .Alert)

--- a/podverse/PVDeleter.swift
+++ b/podverse/PVDeleter.swift
@@ -21,10 +21,7 @@ class PVDeleter: NSObject {
             deleteEpisode(episodesToRemove[i],completion: nil)
         }
         
-        CoreDataHelper.sharedInstance.deleteItemFromCoreData(podcast, completionBlock: { () -> Void in
-            CoreDataHelper.saveCoreData(nil)
-        })
-
+        CoreDataHelper.sharedInstance.deleteItemFromCoreData(podcast)
     }
     
     func deleteEpisode(episode: Episode, completion:(()->())? ) {
@@ -61,14 +58,7 @@ class PVDeleter: NSObject {
             PVUtility.deleteEpisodeFromDiskWithName(fileName)
         }
         
-        CoreDataHelper.sharedInstance.deleteItemFromCoreData(episode, completionBlock: { () -> Void in
-            CoreDataHelper.saveCoreData({ (saved) -> Void in
-                if let completion = completion {
-                    completion()
-                }
-            })
-        })
-
+        CoreDataHelper.sharedInstance.deleteItemFromCoreData(episode)
     }
     
 }

--- a/podverse/PVDownloader.swift
+++ b/podverse/PVDownloader.swift
@@ -43,7 +43,7 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
                 DLEpisodesList.shared.downloadingEpisodes.append(episode)
             }
             
-            CoreDataHelper.saveCoreData(nil)
+            CoreDataHelper.sharedInstance.saveCoreData(nil)
             let task = beginBackgroundTask()
             downloadTask.resume()
             endBackgroundTask(task)
@@ -62,7 +62,7 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
                 episode.taskIdentifier = NSNumber(integer:downloadTask.taskIdentifier)
                 episode.taskResumeData = nil
                 
-                CoreDataHelper.saveCoreData(nil)
+                CoreDataHelper.sharedInstance.saveCoreData(nil)
                 
                 downloadTask.resume()
             }
@@ -76,7 +76,7 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
                             if (resumeData != nil) {
                                 episode.taskResumeData = resumeData
                                 episode.taskIdentifier = nil
-                                CoreDataHelper.saveCoreData(nil)
+                                CoreDataHelper.sharedInstance.saveCoreData(nil)
                             }
                         }
                     }
@@ -95,7 +95,6 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
             
             if let resumeData = error?.userInfo[NSURLSessionDownloadTaskResumeData] as? NSData {
                 episode.taskResumeData = resumeData
-                CoreDataHelper.saveCoreData(nil)
             }
         }
     }
@@ -184,7 +183,7 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
                     episode.taskIdentifier = nil
                     
                     // Save the downloadedMediaFileDestination with the object
-                    CoreDataHelper.saveCoreData(nil)
+                    CoreDataHelper.sharedInstance.saveCoreData(nil)
                     
                     let downloadHasFinishedUserInfo = ["episode":episode]
                     

--- a/podverse/PVMediaPlayer.swift
+++ b/podverse/PVMediaPlayer.swift
@@ -119,7 +119,7 @@ class PVMediaPlayer: NSObject {
     func saveCurrentTimeAsPlaybackPosition() {
         if let playingEpisode = self.nowPlayingEpisode {
             playingEpisode.playbackPosition = CMTimeGetSeconds(avPlayer.currentTime())
-            CoreDataHelper.saveCoreData(nil)
+            CoreDataHelper.sharedInstance.saveCoreData(nil)
         }
     }
     


### PR DESCRIPTION
After returning to the project with a fresh perspective, I realized that the fact that we are using the shared instance means that we do not need a global reference to the moc. when initializing the helper, we set al the moc information inside the saveQueue and that should be enough to work with it from any thread we want.
I stress tested this as much as I could but PLEASE PLEASE PLEASE download this branch and stress test it before merging it in. 