### PR TITLE
Set merge policy to prevent conflicts when subscribing to podcasts

### DIFF
--- a/PodcastsTableViewController.swift
+++ b/PodcastsTableViewController.swift
@@ -29,6 +29,9 @@ class PodcastsTableViewController: UIViewController, UITableViewDataSource, UITa
     func loadData() {
         podcastsArray = CoreDataHelper.sharedInstance.fetchEntities("Podcast", predicate: nil) as! [Podcast]
         podcastsArray.sortInPlace{ $0.title.removeArticles() < $1.title.removeArticles() }
+        
+        // TODO: The answer in the SO link below claims that using a string in a predicate can cause performance issues. Well below we are passing a podcast object as the NSPredicate. If strings can cause performance issues, wouldn't this cause egregiously horrible performance issues? I know this "fetchOnlyEntityWithMostRecentPubDate" has had mutating array crashes in the past (although I haven't seen it happen since mid-February). Could it be that we are using a bad predicate? If yes, how can we make this more performant?
+        // http://stackoverflow.com/questions/30368945/saving-coredata-on-background-thread-causes-fetching-into-a-deadlock-and-crash
 
         // Set pubdate in cell equal to most recent episode's pubdate
         for podcast in podcastsArray {

--- a/podverse/CoreDataHelper.swift
+++ b/podverse/CoreDataHelper.swift
@@ -28,6 +28,10 @@ class CoreDataHelper {
         self.moc = NSManagedObjectContext(concurrencyType: .PrivateQueueConcurrencyType)
         self.moc.persistentStoreCoordinator = psc
         
+        // TODO to review: I added the line below to address the "merge conflict" issues that would happen when subscribing to many podcasts rapidly. I think it tells Core Data to always save the newest object when a merge conflict exists...anyway after adding this line, I could not reproduce the merge conflict issue again.
+        // Reference: http://stackoverflow.com/questions/4405912/iphone-coredata-error-nsmergeconflict-for-nsmanagedobject
+        self.moc.mergePolicy = NSMergePolicy(mergeType: NSMergePolicyType.MergeByPropertyObjectTrumpMergePolicyType)
+        
         self.mediaPlayerMoc = NSManagedObjectContext(concurrencyType: .PrivateQueueConcurrencyType)
         self.mediaPlayerMoc.persistentStoreCoordinator = psc
         

--- a/podverse/PVDownloader.swift
+++ b/podverse/PVDownloader.swift
@@ -113,10 +113,11 @@ class PVDownloader: NSObject, NSURLSessionDelegate, NSURLSessionDownloadDelegate
                     
                     let totalProgress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
                     
+                    // TODO: This line crashed when subscribing to many podcasts quickly ("Thread 11: EXC_BAD_ACCESS"). Could this be a source of mutating array issues? In this case the NSManaged Episode object is getting updated very rapidly, and if the MOC is getting rapidly saved in other functions, could this cause a problem? I don't think the downloadProgress needs to be saved in Core Data at all. We just need the DownloadsTableVC to update and display the downloadProgress for that episode. Maybe we should just use the notificationcenter to post updates to the DownloadsTableVC, and stop updating the .downloadProgress and .mediaBytes properties in this function?
                     episode.downloadProgress = Float(totalProgress)
                     episode.mediaBytes = Float(totalBytesExpectedToWrite)
                     
-                    // TODO: Is this Notification actually doing anything? I don't see the downloadHasProgressed notification getting used anywhere...
+                    // TODO: This notification is doing nothing.I don't see the downloadHasProgressed notification getting used anywhere...maybe we should use this or something similar to update the DownloadTableVC progress?
                     let downloadHasProgressedUserInfo = ["episode":episode]
                     
                     NSNotificationCenter.defaultCenter().postNotificationName(Constants.kDownloadHasProgressed, object: self, userInfo: downloadHasProgressedUserInfo)


### PR DESCRIPTION
-Set merge policy to prevent conflicts when subscribing to podcasts quickly. 

-Add mutating array TODO notes