### PR TITLE
Fixed share playlist crash, also fixed go to player crash

### DIFF
--- a/PodcastsTableViewController.swift
+++ b/PodcastsTableViewController.swift
@@ -183,9 +183,9 @@ class PodcastsTableViewController: UIViewController {
         } else if segue.identifier == "Show Playlist" {
             let playlistViewController = segue.destinationViewController as! PlaylistViewController
             if let index = tableView.indexPathForSelectedRow {
-                playlistViewController.playlist = playlists[index.row]
+                playlistViewController.playlistObjectId = playlists[index.row].objectID
             }
-        } else if segue.identifier == "Podcasts to Now Playing" {
+        } else if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }
@@ -228,10 +228,6 @@ class PodcastsTableViewController: UIViewController {
         
         
         self.tableView.reloadData()
-    }
-    
-    override func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Podcasts to Now Playing", sender: nil)
     }
     
     private func updateParsingActivity() {

--- a/PodcastsTableViewController.swift
+++ b/PodcastsTableViewController.swift
@@ -185,7 +185,7 @@ class PodcastsTableViewController: UIViewController {
             if let index = tableView.indexPathForSelectedRow {
                 playlistViewController.playlistObjectId = playlists[index.row].objectID
             }
-        } else if segue.identifier == "To Now Playing" {
+        } else if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/Base.lproj/Main.storyboard
+++ b/podverse/Base.lproj/Main.storyboard
@@ -126,7 +126,7 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8 / 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.65000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="Vnu-69-YIj">
                                         <rect key="frame" x="38" y="10" width="43" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -181,7 +181,7 @@
                         <outlet property="tableView" destination="bVH-xt-Ob5" id="tby-vu-7B7"/>
                         <segue destination="jfK-O4-nvL" kind="show" identifier="Show Episodes" id="Wxg-po-9OF"/>
                         <segue destination="QaS-ox-B9v" kind="show" identifier="Show Playlist" id="Eqj-Vy-Alg"/>
-                        <segue destination="jDs-me-457" kind="show" identifier="Podcasts to Now Playing" id="fwx-gG-V2G"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="fwx-gG-V2G"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yec-mx-vO6" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -369,7 +369,7 @@
                         <outlet property="headerSummaryLabel" destination="LOq-p7-G5w" id="LTS-gX-rvf"/>
                         <outlet property="headerView" destination="Sgy-kf-zDQ" id="eVX-5m-HMz"/>
                         <outlet property="tableView" destination="Zi8-pK-weV" id="0TF-9T-zJv"/>
-                        <segue destination="jDs-me-457" kind="show" identifier="Episodes to Now Playing" id="ug1-KO-0I5"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="ug1-KO-0I5"/>
                         <segue destination="w0b-bb-hu2" kind="show" identifier="Show Clips" id="Vxi-eO-V9n"/>
                     </connections>
                 </viewController>
@@ -515,7 +515,7 @@
                         <outlet property="headerSummaryLabel" destination="Oz6-yG-qZf" id="dRd-ak-ItB"/>
                         <outlet property="headerView" destination="7Mz-qe-lLf" id="dPc-5a-cfU"/>
                         <outlet property="tableView" destination="EiQ-w1-APP" id="QSa-p4-LXJ"/>
-                        <segue destination="jDs-me-457" kind="show" identifier="Clips to Now Playing" id="CAr-w1-zrt"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="CAr-w1-zrt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QxJ-Wy-uAm" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -922,7 +922,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gtd-Og-dc0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4535" y="1021"/>
+            <point key="canvasLocation" x="4508" y="1221"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="jNn-5c-44i">
@@ -1271,7 +1271,7 @@
                         <barButtonItem key="backBarButtonItem" title=" " id="ju5-3M-fuB"/>
                     </navigationItem>
                     <connections>
-                        <segue destination="jDs-me-457" kind="show" identifier="Find to Now Playing" id="TGC-Eq-beX"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="TGC-Eq-beX"/>
                         <segue destination="RGb-c9-5c2" kind="show" identifier="Search for Podcasts" id="3FJ-Fu-qtZ"/>
                     </connections>
                 </tableViewController>
@@ -1369,7 +1369,7 @@
                         <outlet property="searchBar" destination="JA2-8J-nh6" id="YZb-f6-Qts"/>
                         <outlet property="tableView" destination="Fb6-Sb-O07" id="1y7-Gv-Vav"/>
                         <segue destination="pXc-eT-gZd" kind="show" identifier="Show Podcast Profile" id="YZs-t6-IMw"/>
-                        <segue destination="jDs-me-457" kind="show" identifier="Find Search to Now Playing" id="ltZ-MZ-73u"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="ltZ-MZ-73u"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pHl-D1-pLL" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1518,7 +1518,7 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="Lhk-s2-uMY" id="QTy-11-7lx"/>
-                        <segue destination="jDs-me-457" kind="show" identifier="Playlist to Now Playing" id="SeK-Nv-Ovw"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="SeK-Nv-Ovw"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sik-8l-1AU" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1721,7 +1721,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </refreshControl>
                     <connections>
-                        <segue destination="jDs-me-457" kind="show" identifier="Downloads to Now Playing" id="Xc1-wE-NTg"/>
+                        <segue destination="jDs-me-457" kind="show" identifier="To Now Playing" id="Xc1-wE-NTg"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RED-61-AXE" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1736,6 +1736,6 @@
         <image name="Tab-Podcasts" width="25" height="25"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="fwx-gG-V2G"/>
+        <segue reference="SeK-Nv-Ovw"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/podverse/ClipsTableViewController.swift
+++ b/podverse/ClipsTableViewController.swift
@@ -112,7 +112,7 @@ class ClipsTableViewController: UIViewController, UITableViewDataSource, UITable
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let selectedClip = clipsArray[indexPath.row]
         self.pvMediaPlayer.loadClipDownloadedMediaFileOrStreamAndPlay(selectedClip.objectID)
-        self.performSegueWithIdentifier("To Now Playing", sender: nil)
+        self.segueToNowPlaying()
     }
 
 
@@ -155,7 +155,7 @@ class ClipsTableViewController: UIViewController, UITableViewDataSource, UITable
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "To Now Playing" {
+        if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/ClipsTableViewController.swift
+++ b/podverse/ClipsTableViewController.swift
@@ -38,10 +38,6 @@ class ClipsTableViewController: UIViewController, UITableViewDataSource, UITable
         }
     }
     
-    override func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Clips to Now Playing", sender: nil)
-    }
-    
     func removePlayerButtonAndReload() {
         self.removePlayerNavButton()
         self.loadData()
@@ -116,7 +112,7 @@ class ClipsTableViewController: UIViewController, UITableViewDataSource, UITable
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let selectedClip = clipsArray[indexPath.row]
         self.pvMediaPlayer.loadClipDownloadedMediaFileOrStreamAndPlay(selectedClip.objectID)
-        self.performSegueWithIdentifier("Clips to Now Playing", sender: nil)
+        self.performSegueWithIdentifier("To Now Playing", sender: nil)
     }
 
 
@@ -159,7 +155,7 @@ class ClipsTableViewController: UIViewController, UITableViewDataSource, UITable
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "Clips to Now Playing" {
+        if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/Constants.swift
+++ b/podverse/Constants.swift
@@ -48,4 +48,6 @@ struct Constants {
             }
         }
     }
+    
+    static let TO_PLAYER_SEGUE_ID = "To Now Playing"
 }

--- a/podverse/DownloadsTableViewController.swift
+++ b/podverse/DownloadsTableViewController.swift
@@ -133,7 +133,7 @@ class DownloadsTableViewController: UITableViewController {
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "To Now Playing" {
+        if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/DownloadsTableViewController.swift
+++ b/podverse/DownloadsTableViewController.swift
@@ -19,10 +19,6 @@ class DownloadsTableViewController: UITableViewController {
         }
     }
     
-    override func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Downloads to Now Playing", sender: nil)
-    }
-    
     func reloadDownloadTable() {
         self.tableView.reloadData()
     }
@@ -137,7 +133,7 @@ class DownloadsTableViewController: UITableViewController {
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "Downloads to Now Playing" {
+        if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/EpisodesTableViewController.swift
+++ b/podverse/EpisodesTableViewController.swift
@@ -75,10 +75,6 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
         self.tableView.reloadData()
     }
     
-    override func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Episodes to Now Playing", sender: nil)
-    }
-    
     func removePlayerNavButtonAndReload() {
         self.removePlayerNavButton()
         self.loadData()
@@ -95,7 +91,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
                     pvMediaPlayer.saveCurrentTimeAsPlaybackPosition()
                 }
                 pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                self.performSegueWithIdentifier("Episodes to Now Playing", sender: nil)
+                self.performSegueWithIdentifier("To Now Playing", sender: nil)
             } else {
                 PVDownloader.sharedInstance.startDownloadingEpisode(selectedEpisode)
                 cell.downloadPlayButton.setTitle("DLing", forState: .Normal)
@@ -236,7 +232,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
             if selectedEpisode.fileName != nil {
                 episodeActions.addAction(UIAlertAction(title: "Play Episode", style: .Default, handler: { action in
                     self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                    self.performSegueWithIdentifier("Episodes to Now Playing", sender: nil)
+                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
                 }))
             } else {
                 if selectedEpisode.taskIdentifier != nil {
@@ -259,7 +255,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
             
             episodeActions.addAction(UIAlertAction (title: "Stream Episode", style: .Default, handler: { action in
                 self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                self.performSegueWithIdentifier("Episodes to Now Playing", sender: nil)
+                self.performSegueWithIdentifier("To Now Playing", sender: nil)
             }))
             
             episodeActions.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
@@ -317,7 +313,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
     
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "Episodes to Now Playing" {
+        if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         } else if segue.identifier == "Show Clips" {

--- a/podverse/EpisodesTableViewController.swift
+++ b/podverse/EpisodesTableViewController.swift
@@ -91,7 +91,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
                     pvMediaPlayer.saveCurrentTimeAsPlaybackPosition()
                 }
                 pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                self.segueToNowPlaying()
             } else {
                 PVDownloader.sharedInstance.startDownloadingEpisode(selectedEpisode)
                 cell.downloadPlayButton.setTitle("DLing", forState: .Normal)
@@ -232,7 +232,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
             if selectedEpisode.fileName != nil {
                 episodeActions.addAction(UIAlertAction(title: "Play Episode", style: .Default, handler: { action in
                     self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                    self.segueToNowPlaying()
                 }))
             } else {
                 if selectedEpisode.taskIdentifier != nil {
@@ -255,7 +255,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
             
             episodeActions.addAction(UIAlertAction (title: "Stream Episode", style: .Default, handler: { action in
                 self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(selectedEpisode.objectID)
-                self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                self.segueToNowPlaying()
             }))
             
             episodeActions.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
@@ -313,7 +313,7 @@ class EpisodesTableViewController: UIViewController, UITableViewDataSource, UITa
     
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "To Now Playing" {
+        if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         } else if segue.identifier == "Show Clips" {

--- a/podverse/FindSearchTableViewController.swift
+++ b/podverse/FindSearchTableViewController.swift
@@ -124,10 +124,6 @@ class FindSearchTableViewController: UIViewController, UITableViewDataSource, UI
         }
     }
     
-    override func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Find Search to Now Playing", sender: nil)
-    }
-    
     func searchBarSearchButtonClicked(searchBar: UISearchBar) {
         searchItunesFor(searchBar.text!)
         searchBar.resignFirstResponder()
@@ -237,7 +233,7 @@ class FindSearchTableViewController: UIViewController, UITableViewDataSource, UI
                 podcastProfileViewController.searchResultPodcast = iTunesSearchPodcastArray[index.row]
             }
         }
-        else if segue.identifier == "Find Search to Now Playing" {
+        else if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/FindSearchTableViewController.swift
+++ b/podverse/FindSearchTableViewController.swift
@@ -233,7 +233,7 @@ class FindSearchTableViewController: UIViewController, UITableViewDataSource, UI
                 podcastProfileViewController.searchResultPodcast = iTunesSearchPodcastArray[index.row]
             }
         }
-        else if segue.identifier == "To Now Playing" {
+        else if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/FindTableViewController.swift
+++ b/podverse/FindTableViewController.swift
@@ -136,7 +136,7 @@ class FindTableViewController: UITableViewController {
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "To Now Playing" {
+        if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/FindTableViewController.swift
+++ b/podverse/FindTableViewController.swift
@@ -136,7 +136,7 @@ class FindTableViewController: UITableViewController {
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "Find to Now Playing" {
+        if segue.identifier == "To Now Playing" {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/Info.plist
+++ b/podverse/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>5</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/podverse/PlaylistTableViewController.swift
+++ b/podverse/PlaylistTableViewController.swift
@@ -42,35 +42,27 @@ class PlaylistViewController: UIViewController, UITableViewDataSource, UITableVi
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(removePlayerNavButtonAndReload), name: Constants.kPlayerHasNoItem, object: nil)
         
-    }
-    
-    override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        loadData()
+        tableView.reloadData()
         
         // Set navigation bar styles
         navigationItem.title = "Playlist"
         
-        if pvMediaPlayer.nowPlayingEpisode != nil || pvMediaPlayer.nowPlayingClip != nil {
-            let shareBarButton = UIBarButtonItem(title: "Share", style: .Plain, target: self, action: #selector(PlaylistViewController.showPlaylistShare(_:)))
-            let playerBarButton = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(PlaylistViewController.segueToNowPlaying))
-            navigationItem.rightBarButtonItems = [playerBarButton, shareBarButton]
-        } else {
-            let shareBarButton = UIBarButtonItem(title: "Share", style: .Plain, target: self, action: #selector(PlaylistViewController.showPlaylistShare(_:)))
-            navigationItem.rightBarButtonItem = shareBarButton
-        }
+        let shareBarButton = UIBarButtonItem(title: "Share", style: .Plain, target: self, action: #selector(PlaylistViewController.showPlaylistShare(_:)))
         
-        self.addPlayerNavButton()
+        navigationItem.rightBarButtonItems = [shareBarButton]
     }
     
-    func loadData() {
-        tableView.reloadData()
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        if pvMediaPlayer.nowPlayingEpisode != nil || pvMediaPlayer.nowPlayingClip != nil {
+            let playerBarButton = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(PlaylistViewController.segueToNowPlaying))
+            navigationItem.rightBarButtonItems?.insert(playerBarButton, atIndex: 0)
+        }
     }
     
     func removePlayerNavButtonAndReload() {
         self.removePlayerNavButton()
-        self.loadData()
+        self.tableView.reloadData()
     }
     
     func showPlaylistShare(sender: UIBarButtonItem) {

--- a/podverse/PlaylistTableViewController.swift
+++ b/podverse/PlaylistTableViewController.swift
@@ -54,7 +54,7 @@ class PlaylistViewController: UIViewController, UITableViewDataSource, UITableVi
         
         if pvMediaPlayer.nowPlayingEpisode != nil || pvMediaPlayer.nowPlayingClip != nil {
             let shareBarButton = UIBarButtonItem(title: "Share", style: .Plain, target: self, action: #selector(PlaylistViewController.showPlaylistShare(_:)))
-            let playerBarButton = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(PlaylistViewController.segueToNowPlaying(_:)))
+            let playerBarButton = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(PlaylistViewController.segueToNowPlaying))
             navigationItem.rightBarButtonItems = [playerBarButton, shareBarButton]
         } else {
             let shareBarButton = UIBarButtonItem(title: "Share", style: .Plain, target: self, action: #selector(PlaylistViewController.showPlaylistShare(_:)))
@@ -173,12 +173,12 @@ class PlaylistViewController: UIViewController, UITableViewDataSource, UITableVi
             if episode.fileName != nil {
                 playlistItemActions.addAction(UIAlertAction(title: "Play", style: .Default, handler: { action in
                 self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(episode.objectID)
-                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                    self.segueToNowPlaying()
                 }))
             } else {
                 playlistItemActions.addAction(UIAlertAction(title: "Stream", style: .Default, handler: { action in
                 self.pvMediaPlayer.loadEpisodeDownloadedMediaFileOrStreamAndPlay(episode.objectID)
-                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                    self.segueToNowPlaying()
                 }))
             }
             
@@ -195,12 +195,12 @@ class PlaylistViewController: UIViewController, UITableViewDataSource, UITableVi
             if clip.episode.fileName != nil {
                 playlistItemActions.addAction(UIAlertAction(title: "Play", style: .Default, handler: { action in
                     self.pvMediaPlayer.loadClipDownloadedMediaFileOrStreamAndPlay(clip.objectID)
-                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                    self.segueToNowPlaying()
                 }))
             } else {
                 playlistItemActions.addAction(UIAlertAction(title: "Stream", style: .Default, handler: { action in
                     self.pvMediaPlayer.loadClipDownloadedMediaFileOrStreamAndPlay(clip.objectID)
-                    self.performSegueWithIdentifier("To Now Playing", sender: nil)
+                    self.segueToNowPlaying()
                 }))
             }
             
@@ -253,7 +253,7 @@ class PlaylistViewController: UIViewController, UITableViewDataSource, UITableVi
     
     // MARK: - Navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "To Now Playing" {
+        if segue.identifier == Constants.TO_PLAYER_SEGUE_ID {
             let mediaPlayerViewController = segue.destinationViewController as! MediaPlayerViewController
             mediaPlayerViewController.hidesBottomBarWhenPushed = true
         }

--- a/podverse/UIViewController+MediaPlayerUI.swift
+++ b/podverse/UIViewController+MediaPlayerUI.swift
@@ -12,7 +12,7 @@ extension UIViewController {
     // If there is a now playing episode or clip, add Now Playing button to nav bar
     func addPlayerNavButton() {
         if PVMediaPlayer.sharedInstance.nowPlayingEpisode != nil || PVMediaPlayer.sharedInstance.nowPlayingClip != nil {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(segueToNowPlaying(_:)))
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Player", style: .Plain, target: self, action: #selector(segueToNowPlaying))
         }
         else {
             navigationItem.rightBarButtonItem = nil
@@ -26,8 +26,8 @@ extension UIViewController {
         }
     }
     
-    func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("To Now Playing", sender: nil)
+    func segueToNowPlaying() {
+        self.performSegueWithIdentifier(Constants.TO_PLAYER_SEGUE_ID, sender: nil)
     }
 }
 

--- a/podverse/UIViewController+MediaPlayerUI.swift
+++ b/podverse/UIViewController+MediaPlayerUI.swift
@@ -27,7 +27,7 @@ extension UIViewController {
     }
     
     func segueToNowPlaying(sender: UIBarButtonItem) {
-        self.performSegueWithIdentifier("Find to Now Playing", sender: nil)
+        self.performSegueWithIdentifier("To Now Playing", sender: nil)
     }
 }
 


### PR DESCRIPTION
The idea of segueing to player is that we just have one name the the segue. this way, the method in the extension can be called from anywhere and without the need to check for the segue name.

The only thing we need to make sure is to add the "To Now Playing" Identifier to any segues we add in the storyboard pointing to the media player VC