### PR TITLE
chore: consolidate monorepo deployment plans and update Makefile

### DIFF
--- a/.llm/history/active/monorepo-deploys-alpha-part-01.md
+++ b/.llm/history/active/monorepo-deploys-alpha-part-01.md
@@ -1,0 +1,41 @@
+
+### Session - 2026-01-26
+
+#### Prompt (Developer)
+looks at the mono repo ansible related alpha deploy plans and create a plan to work on them
+
+#### Prompt (Developer)
+these are the plans that should all be part of the same project (with screenshot showing split plan files)
+
+#### Prompt (Developer)
+execute the plan starting with file consolidation
+
+#### Key Decisions
+- Created new `podverse_monorepo` role for alpha (cleanest separation from production)
+- Kept `podverse_ops` role unchanged for production/sandbox deployments
+- Consolidated plan files from `monorepo-deploys-alpha/` into `monorepo-migration/16-jenkins-ansible-monorepo/`
+- Alpha config files deployed to `/opt/podverse/infra/config/alpha/` instead of `/opt/podverse-ops/config/`
+
+#### Files Modified (podverse repo)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/00-overview.md` (new)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/01-repo-checkout-and-sparse.md` (moved)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/02-alpha-config-destinations.md` (moved)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/03-role-files-hierarchy.md` (moved)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/04-alpha-assets-check.md` (moved)
+- `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/05-validation.md` (moved)
+- Deleted: `.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates.md`
+- Deleted: `.llm/plans/active/monorepo-deploys-alpha/` directory
+
+#### Files Modified (podverse-ansible repo)
+- `roles/podverse_monorepo/tasks/main.yaml` (new role for monorepo sparse checkout)
+- `podverse-alpha-srv.yaml` (updated to use podverse_monorepo role)
+- `podverse-alpha-aux.yaml` (updated to use podverse_monorepo role)
+- `roles/podverse_alpha_api_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_db_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_keyvaldb_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_management_api_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_management_db_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_mq_conf/tasks/main.yml` (updated paths)
+- `roles/podverse_alpha_workers_conf/tasks/main.yml` (updated paths)
+- Moved all alpha config files from `files/opt/podverse-ops/config/` to `files/opt/podverse/infra/config/alpha/`
+- `README.md` (added alpha monorepo documentation section)

--- a/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-01.md
+++ b/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-01.md
@@ -1,0 +1,135 @@
+### Session 1 - 2026-01-26
+
+#### Prompt (Developer)
+
+I am still in the process of migrating podverse from a many repo setup, to a monorepo setup
+
+there will only be 3 repos going forward
+
+podverse-ansible - deployment and credential helpers (private repo)
+partytime - fork of a 3rd party library
+podverse - everything else, the podverse monorepo
+
+we will no longer need podverse-ops at all, as that should be replaced by the podverse monorepo
+
+before the monorepo, i had many jenkins pipelines and jobs setup to make deployment easier
+
+podverse-ansible, jenkins jobs, and all of these related files need to be updated to be able to work with the monorepo setup
+
+instead of cloning podverse-ops on a server, we will now clone podverse and jenkins will now use the corresponding files it needs through there
+
+if there is a way to minimize parts of the repo so the server does not have to clone ALL of the contents, make recommendations on how to handle that (we don't need the packages or apps, because the already published docker images should handle that)
+
+podverse-ansible will need to be thoroughly updated to handle the new file hierarchy
+
+#### Prompt (Developer)
+
+after you make the plan, split the plan up into smaller plans, with a goal of around no more than 300 lines per plan. create thorough plans, and save the plans within the .llm plans directory as per skill recommendations, so after this planning stage, i can run the plans one by one (or in parallel if possible)
+
+note all the path changes and description changes and anything else that must happen to handle the monorepo migration in podverse-ansible and the jenkins files
+
+#### Key Decisions
+
+- Created a split plan set under .llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo.
+- Focused on Jenkins sparse checkout and monorepo path updates for pipelines and ansible roles.
+- Documented key path replacements (/opt/podverse-ops -> /opt/podverse, infra/ paths).
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/00-master-plan.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md
+
+### Session 2 - 2026-01-26
+
+#### Prompt (Developer)
+
+note: the monorepo migration should only affect the alpha environment for our new next gen platform. if any of your changes may affect the legacy production envionrment app, those changes should not be applied
+
+#### Key Decisions
+
+- Updated split plans to explicitly scope changes to alpha only.
+- Removed sandbox/prod ansible role updates from the plan.
+- Added scope guards to Jenkins and docs plan steps.
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/00-master-plan.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md
+
+### Session 3 - 2026-01-26
+
+#### Prompt (Developer)
+
+if there are new files needed (does sandbox overlap with legacy and next gen?) then make sure making those new files is included in your plans
+
+#### Key Decisions
+
+- Added explicit steps to create alpha-specific files if sandbox/legacy overlap is discovered.
+- Updated master plan and sub-plans to include new-file creation and documentation.
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/00-master-plan.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md
+
+### Session 4 - 2026-01-26
+
+#### Prompt (Developer)
+
+merge the history files into 01
+
+#### Key Decisions
+
+- Merged session entries from part-02 and part-03 into part-01.
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-01.md
+- /Users/mitcheldowney/repos/podverse/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-02.md
+- /Users/mitcheldowney/repos/podverse/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-03.md
+
+### Session 5 - 2026-01-26
+
+#### Prompt (Developer)
+
+implement @podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md
+
+#### Key Decisions
+
+- Added sparse checkout paths and clean-before-checkout to the alpha Jenkins SCM template.
+- Disabled lightweight checkout so the sparse workspace is fully materialized.
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/scm-job.xml
+- /Users/mitcheldowney/repos/podverse/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-01.md
+
+### Session 6 - 2026-01-26
+
+#### Prompt (Developer)
+
+Implement the plan as specified, it is attached for your reference. Do NOT edit the plan file itself.
+
+To-do's from the plan have already been created. Do not create them again. Mark them as in_progress as you work, starting with the first one. Don't stop until you have completed all the to-dos.
+
+#### Key Decisions
+
+- Split Plan 03 into five alpha-scoped subplans under monorepo-deploys-alpha.
+- Scoped each subplan to alpha-only changes and preserved sandbox/prod exclusions.
+
+#### Files Modified
+
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-deploys-alpha/03-ansible-monorepo-path-updates/01-repo-checkout-and-sparse.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-deploys-alpha/03-ansible-monorepo-path-updates/02-alpha-config-destinations.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-deploys-alpha/03-ansible-monorepo-path-updates/03-role-files-hierarchy.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-deploys-alpha/03-ansible-monorepo-path-updates/04-alpha-assets-check.md
+- /Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-deploys-alpha/03-ansible-monorepo-path-updates/05-validation.md
+- /Users/mitcheldowney/repos/podverse/.llm/history/active/monorepo-deploys-alpha/monorepo-deploys-alpha-part-01.md

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/00-master-plan.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/00-master-plan.md
@@ -1,0 +1,45 @@
+# Jenkins + Ansible Monorepo Migration (Split Plan)
+
+## Overview
+
+Migrate Jenkins jobs and podverse-ansible roles from the legacy `podverse-ops` repo structure to the `podverse` monorepo layout, and introduce sparse checkouts to minimize server footprint.
+
+## Goals
+
+- Jenkins jobs reference monorepo paths under `/opt/podverse`.
+- Jenkins job definitions use sparse checkout to pull only `infra/`, `pipelines/jenkins/`, `scripts/`, and Makefiles.
+- podverse-ansible clones `podverse` (not `podverse-ops`) and places config under the monorepo `infra/config/` hierarchy.
+- Documentation reflects the new repo and paths.
+- Alpha-only scope: do not change legacy production or sandbox deployment behavior.
+- If new files are required to avoid overlap with legacy/sandbox, include them explicitly.
+
+## Sub-Plans
+
+- [01-jenkins-import-and-sparse-checkout.md](/Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md)
+- [02-jenkins-pipeline-path-updates.md](/Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md)
+- [03-ansible-monorepo-path-updates.md](/Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates.md)
+- [04-docs-validation-and-cleanup.md](/Users/mitcheldowney/repos/podverse/.llm/plans/active/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md)
+
+## Key Path Changes to Apply Everywhere
+
+- Replace `/opt/podverse-ops` with `/opt/podverse`.
+- Docker compose paths:
+  - Legacy: `/opt/podverse-ops/docker-compose/alpha/...`
+  - Monorepo: `/opt/podverse/infra/docker/alpha/...`
+- Config/env file paths:
+  - Legacy: `/opt/podverse-ops/config/...`
+  - Monorepo: `/opt/podverse/infra/config/alpha/...` (alpha only)
+- Script paths:
+  - Legacy: `/opt/podverse-ops/scripts/...`
+  - Monorepo: `/opt/podverse/scripts/...`
+- Jenkinsfiles location:
+  - Legacy: `podverse-ops/pipelines/alpha/`
+  - Monorepo: `podverse/pipelines/jenkins/alpha/`
+
+## Plan Notes
+
+- These plans focus only on Jenkins pipelines and podverse-ansible.
+- No app/package code changes are required.
+- Jenkins agent checkout path is assumed to be `/opt/podverse`.
+- Production and sandbox paths should remain untouched.
+- If sandbox overlaps with legacy or next-gen, plan steps include creating new alpha-specific files.

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/01-jenkins-import-and-sparse-checkout.md
@@ -1,0 +1,57 @@
+# Plan 01 - Jenkins Import + Sparse Checkout
+
+## Objective
+
+Update Jenkins job definitions to pull the monorepo with sparse checkout, so only deployment-related directories are retrieved.
+
+## Key Files
+
+- Jenkins job template: [`/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/scm-job.xml`](/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/scm-job.xml)
+- Import script: [`/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/import.sh`](/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/import.sh)
+
+## Current SCM Template (reference)
+
+```6:25:/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/scm-job.xml
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/podverse/podverse.git</url>
+          <credentialsId>d793d818-3df6-4f30-b137-c849b43ce6fe</credentialsId>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>*/v5-develop</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <extensions/>
+    </scm>
+    <scriptPath>REPLACE_SCRIPT_PATH</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+```
+
+## Steps
+
+- Add a Jenkins Git SCM extension for sparse checkout in `scm-job.xml`.
+  - Use `SparseCheckoutPaths` and list only what Jenkins needs, for example:
+    - `pipelines/jenkins/`
+    - `infra/docker/`
+    - `infra/config/`
+    - `scripts/`
+    - `Makefile`
+    - `Makefile.alpha`
+  - Consider adding `CleanBeforeCheckout` to avoid stale files.
+- Decide whether to set `<lightweight>false</lightweight>` if Jenkins is not performing a full checkout for pipeline steps. If jobs rely on workspace files (Makefile/scripts), disable lightweight checkout.
+- If job folder names or branch names change for monorepo, update in `scm-job.xml` and confirm `import.sh` still discovers the Jenkinsfiles in `pipelines/jenkins/alpha/`.
+- Scope guard: only update alpha Jenkins job definitions.
+
+## Validation
+
+- Import jobs with `import.sh` and confirm Jenkins workspaces only contain the sparse set.
+- Run one pipeline (e.g., `srv_api_up`) and verify it can access:
+  - `infra/docker/alpha/...`
+  - `scripts/ghcr/getLatestAlphaTag.sh`
+  - `Makefile.alpha`

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/02-jenkins-pipeline-path-updates.md
@@ -1,0 +1,53 @@
+# Plan 02 - Jenkins Pipeline Path Updates
+
+## Objective
+
+Ensure all Jenkinsfiles in the monorepo reference the monorepo paths and infra layout, and remove any remaining `podverse-ops` assumptions.
+
+## Key Files
+
+- Jenkinsfiles: [`/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/`](/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/)
+
+## Example of Desired Path Usage
+
+```41:72:/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/Jenkinsfile.srv_api_up
+                    dir('/opt/podverse/infra/docker/alpha/api') {
+                        def apiVersion
+                        if (params.IMAGE_VERSION == 'alpha') {
+                            apiVersion = sh(script: '/opt/podverse/scripts/ghcr/getLatestAlphaTag.sh', returnStdout: true).trim()
+                            if (!apiVersion) {
+                                error('ERROR: No alpha tag found from getLatestAlphaTag.sh')
+                            }
+                        } else {
+                            apiVersion = params.IMAGE_VERSION
+                        }
+                        sh '''#!/bin/bash
+                            set -euo pipefail
+                            sed -e "s|REPLACE_WITH_API_VERSION|''' + apiVersion + '''|g" docker-compose.yml.template > docker-compose.yml
+                        '''
+                    }
+```
+
+## Steps
+
+- Audit all Jenkinsfiles in `pipelines/jenkins/alpha/` for any remaining legacy paths:
+  - `/opt/podverse-ops`
+  - `docker-compose/alpha/...` (legacy root)
+  - `config/` (legacy root)
+  - `scripts/` pointing to old repo location
+- Update paths to monorepo locations:
+  - `infra/docker/alpha/...`
+  - `infra/config/alpha/...`
+  - `scripts/ghcr/...`
+  - `Makefile.alpha` targets run from `/opt/podverse`
+- Verify any templating logic aligns with monorepo templates:
+  - `infra/docker/alpha/*/docker-compose.yml.template`
+- Ensure any pipelines that used `podverse-ops` git pulls or scripts now target the monorepo repo and paths.
+- Scope guard: only alpha Jenkinsfiles should change (avoid touching legacy prod pipelines).
+- If alpha pipelines need new files to avoid sandbox/legacy overlap, create alpha-specific files and update references accordingly.
+
+## Validation
+
+- Run a representative set of pipelines:
+  - `srv_api_up`, `srv_web_up`, `aux_db_up`, `aux_workers_pull`
+- Confirm each pipeline can find all referenced files inside `/opt/podverse` with sparse checkout enabled.

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/00-overview.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/00-overview.md
@@ -1,0 +1,50 @@
+# Plan 03 - podverse-ansible Monorepo Path Updates
+
+## Objective
+
+Update podverse-ansible to clone the `podverse` monorepo (with sparse checkout) and place env/config files under the monorepo `infra/config/` hierarchy.
+
+## Sub-Plans
+
+This plan is broken into 5 sub-plans:
+
+- [01-repo-checkout-and-sparse.md](./01-repo-checkout-and-sparse.md) - Update `podverse_ops` role for monorepo checkout
+- [02-alpha-config-destinations.md](./02-alpha-config-destinations.md) - Update alpha role destination paths
+- [03-role-files-hierarchy.md](./03-role-files-hierarchy.md) - Move role `files/` to match new hierarchy
+- [04-alpha-assets-check.md](./04-alpha-assets-check.md) - Verify alpha assets (Firebase keys)
+- [05-validation.md](./05-validation.md) - End-to-end validation
+
+## Key Files (roles to update)
+
+- Repo checkout: `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_ops/tasks/main.yaml`
+- Alpha env roles:
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_api_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_db_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_keyvaldb_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_management_api_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_management_db_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_mq_conf/tasks/main.yml`
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_workers_conf/tasks/main.yml`
+
+## Out of Scope (do not modify)
+
+- Sandbox roles and production roles must remain untouched.
+
+## Steps
+
+- Update `podverse_ops` role to clone `https://github.com/podverse/podverse.git` into `/opt/podverse` instead of `/opt/podverse-ops`.
+  - Implement sparse checkout (same paths as Jenkins).
+  - Update the legacy symlink `/home/mitch/podverse-ops` to `/home/mitch/podverse` (if still needed).
+- Update all role copy destinations from `/opt/podverse-ops/config/...` to `/opt/podverse/infra/config/{env}/...`.
+  - Alpha only → `/opt/podverse/infra/config/alpha/`
+- Update role `files/` directories to mirror the new destination hierarchy (e.g., move from `roles/*/files/opt/podverse-ops/config/...` to `roles/*/files/opt/podverse/infra/config/...` so Ansible copies match).
+- Verify any non-config assets:
+  - Firebase keys currently staged under `roles/*/files/opt/podverse-ops/config/google/...`
+  - Manticore config under `roles/podverse_prod_db/files/opt/podverse-ops/manticore/...`
+  - Alpha-only assets should move; production assets must remain untouched.
+- If sandbox and legacy share env file names/paths with alpha, add new alpha-specific files under `roles/*/files/opt/podverse/infra/config/alpha/` and update tasks to use them.
+
+## Validation
+
+- Run ansible playbook(s) for alpha/sandbox/prod in a dry-run or staging environment.
+- Confirm env files end up in `infra/config/{env}/` and are picked up by Jenkins/Makefile targets.

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/01-repo-checkout-and-sparse.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/01-repo-checkout-and-sparse.md
@@ -1,0 +1,32 @@
+## Plan 03.01 - Repo Checkout and Sparse Checkout
+
+### Objective
+
+Update the `podverse_ops` role to clone the `podverse` monorepo into `/opt/podverse` with sparse checkout, and adjust any legacy symlink if still required.
+
+### Scope
+
+- In scope: alpha-only deployment paths in `podverse-ansible`.
+- Out of scope: sandbox and production roles.
+
+### Files to Update
+
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_ops/tasks/main.yaml`
+
+### Steps
+
+1. Change the repository URL to `https://github.com/podverse/podverse.git`.
+2. Update the checkout destination from `/opt/podverse-ops` to `/opt/podverse`.
+3. Implement sparse checkout using the same paths defined for Jenkins (from the Jenkins plan).
+4. If still used, update the legacy symlink from `/home/mitch/podverse-ops` to `/home/mitch/podverse`.
+5. Ensure the role continues to clean the checkout before sparse checkout operations (if present).
+
+### Validation
+
+- Confirm `/opt/podverse` contains only the sparse paths after the role runs.
+- If the symlink exists, confirm it points at `/home/mitch/podverse`.
+
+### Notes
+
+- Keep changes limited to alpha deployments.
+- Parent plan: [00-overview.md](./00-overview.md)

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/02-alpha-config-destinations.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/02-alpha-config-destinations.md
@@ -1,0 +1,36 @@
+## Plan 03.02 - Alpha Config Destination Updates
+
+### Objective
+
+Update alpha config role tasks to deploy files under the monorepo hierarchy: `/opt/podverse/infra/config/alpha/`.
+
+### Scope
+
+- In scope: alpha config roles only.
+- Out of scope: sandbox and production roles.
+
+### Files to Update
+
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_api_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_db_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_keyvaldb_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_management_api_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_management_db_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_mq_conf/tasks/main.yml`
+- `/Users/mitcheldowney/repos/podverse-ansible/roles/podverse_alpha_workers_conf/tasks/main.yml`
+
+### Steps
+
+1. Replace any copy destinations under `/opt/podverse-ops/config/...` with `/opt/podverse/infra/config/alpha/...`.
+2. Ensure any directory creation tasks align with the new `infra/config/alpha` path.
+3. If tasks reference role `files/` sources by absolute paths, update them to the new hierarchy (see Plan 03.03 for file moves).
+
+### Validation
+
+- After a dry run, confirm files land under `/opt/podverse/infra/config/alpha/`.
+- Confirm no sandbox or production paths are modified.
+
+### Notes
+
+- Keep updates alpha-only.
+- Parent plan: [00-overview.md](./00-overview.md)

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/03-role-files-hierarchy.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/03-role-files-hierarchy.md
@@ -1,0 +1,33 @@
+## Plan 03.03 - Role Files Hierarchy Updates
+
+### Objective
+
+Move role `files/` content to mirror the new destination hierarchy under `/opt/podverse/infra/config/alpha/` so Ansible `copy` sources match updated destinations.
+
+### Scope
+
+- In scope: alpha-only files in `roles/*/files/`.
+- Out of scope: sandbox and production role files.
+
+### Files/Directories to Update
+
+- Any role files currently under:
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/*/files/opt/podverse-ops/config/...`
+- New location target:
+  - `/Users/mitcheldowney/repos/podverse-ansible/roles/*/files/opt/podverse/infra/config/alpha/...`
+
+### Steps
+
+1. For each alpha role, move files from `roles/*/files/opt/podverse-ops/config/...` to `roles/*/files/opt/podverse/infra/config/alpha/...`.
+2. Ensure the directory structure under `roles/*/files/` mirrors the new destination paths.
+3. If sandbox or legacy share file names/paths with alpha, create alpha-specific copies under the new `infra/config/alpha` path and update tasks to use them.
+
+### Validation
+
+- Confirm each alpha role task references a file path that exists under the new `roles/*/files/opt/podverse/infra/config/alpha/...`.
+- Verify no files were moved for sandbox or production roles.
+
+### Notes
+
+- Use alpha-specific folders when paths collide with legacy or sandbox assets.
+- Parent plan: [00-overview.md](./00-overview.md)

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/04-alpha-assets-check.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/04-alpha-assets-check.md
@@ -1,0 +1,33 @@
+## Plan 03.04 - Alpha Assets Verification
+
+### Objective
+
+Verify alpha-only non-config assets are moved to the new monorepo config hierarchy, while keeping production assets untouched.
+
+### Scope
+
+- In scope: alpha-only assets in `roles/*/files/opt/podverse-ops/config/...`.
+- Out of scope: production assets (must remain unchanged).
+
+### Areas to Check
+
+- Firebase keys currently staged under:
+  - `roles/*/files/opt/podverse-ops/config/google/...`
+- Production-only assets that must remain untouched:
+  - `roles/podverse_prod_db/files/opt/podverse-ops/manticore/...`
+
+### Steps
+
+1. Identify alpha-only assets under `roles/*/files/opt/podverse-ops/config/...`.
+2. Move alpha-only assets to `roles/*/files/opt/podverse/infra/config/alpha/...` in the same relative structure.
+3. Confirm production assets remain in their existing locations and are not referenced by alpha roles.
+
+### Validation
+
+- Alpha playbooks reference assets under `/opt/podverse/infra/config/alpha/...`.
+- Production role file paths remain unchanged.
+
+### Notes
+
+- Keep all changes restricted to alpha scope.
+- Parent plan: [00-overview.md](./00-overview.md)

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/05-validation.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/03-ansible-monorepo-path-updates/05-validation.md
@@ -1,0 +1,27 @@
+## Plan 03.05 - Validation
+
+### Objective
+
+Validate that alpha configuration files and assets land in the new monorepo `infra/config/alpha` hierarchy and are compatible with Jenkins and Makefile targets.
+
+### Scope
+
+- In scope: alpha env validation only.
+- Out of scope: sandbox and production validation.
+
+### Steps
+
+1. Run the alpha ansible playbook(s) in a dry-run or staging environment.
+2. Confirm env files are deployed under `/opt/podverse/infra/config/alpha/`.
+3. Confirm Jenkins/Makefile targets read from the new `infra/config/alpha` paths.
+4. Verify no sandbox or production path changes were applied.
+
+### Acceptance Criteria
+
+- Alpha configs exist under `/opt/podverse/infra/config/alpha/`.
+- Jenkins job configuration and Makefile targets resolve to the new paths.
+- No changes observed in sandbox or production files.
+
+### Notes
+
+- Parent plan: [00-overview.md](./00-overview.md)

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/04-docs-validation-and-cleanup.md
@@ -1,0 +1,32 @@
+# Plan 04 - Docs, Validation, and Cleanup
+
+## Objective
+
+Document the new monorepo-based deployment workflow and verify no lingering references to `podverse-ops` remain in Jenkins or ansible.
+
+## Documentation Targets
+
+- Legacy doc to update or migrate:
+  - `/Users/mitcheldowney/repos/podverse-ops/docs/deploy/alpha/jenkins-deployment-steps-alpha.md`
+- Monorepo docs (if consolidating):
+  - `/Users/mitcheldowney/repos/podverse/docs/` (choose appropriate location for Jenkins/deploy notes)
+- Jenkins pipeline README (if present):
+  - `/Users/mitcheldowney/repos/podverse/pipelines/jenkins/alpha/README.md`
+
+## Steps
+
+- Update or migrate deployment docs to reference:
+  - Repo: `podverse`
+  - Checkout path: `/opt/podverse`
+  - Paths: `infra/docker/`, `infra/config/`, `scripts/`, `pipelines/jenkins/`
+  - Sparse checkout strategy and required paths list
+- Run a path audit across `podverse-ansible` and monorepo Jenkinsfiles to confirm no `podverse-ops` paths remain.
+- If `podverse-ops` repo is no longer used by Jenkins jobs, document deprecation and remove any references from Jenkins job setup instructions.
+- Scope guard: only update alpha deployment docs; do not change legacy production docs.
+- Document any new alpha-specific files created to avoid sandbox/legacy overlap.
+
+## Validation Checklist
+
+- Jenkins import works with sparse checkout and jobs run successfully.
+- Ansible playbooks deploy config to `infra/config/{env}` paths.
+- No job or role still references `/opt/podverse-ops`.

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/04-jenkins-alpha-jobs.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/04-jenkins-alpha-jobs.md
@@ -1,0 +1,169 @@
+# Plan 04 - Jenkins alpha2\_ Job Creation
+
+## Objective
+
+Create new Jenkins jobs with ``naming convention to test the monorepo deployment pipeline separately from existing`alpha\_` jobs.
+
+## Status: Pending
+
+---
+
+## Recommended Creation Order (by dependency/functionality)
+
+### Phase 1: Infrastructure Foundation
+
+These jobs establish the basic infrastructure and should be created first since other jobs depend on them.
+
+| #   | Job Name             | Jenkinsfile                      | Status |
+| --- | -------------------- | -------------------------------- | ------ |
+| 1   | `aux_network_create` | `Jenkinsfile.aux_network_create` | ⬜     |
+| 2   | `srv_network_create` | `Jenkinsfile.srv_network_create` | ⬜     |
+| 3   | `aux_ops_git_pull`   | `Jenkinsfile.aux_ops_git_pull`   | ⬜     |
+| 4   | `srv_ops_git_pull`   | `Jenkinsfile.srv_ops_git_pull`   | ⬜     |
+| 5   | `u_ops_git_pull`     | `Jenkinsfile.u_ops_git_pull`     | ⬜     |
+
+### Phase 2: Database Services (Aux Server)
+
+Database must be running before any services that depend on it.
+
+| #   | Job Name            | Jenkinsfile                     | Status |
+| --- | ------------------- | ------------------------------- | ------ |
+| 6   | `aux_db_init`       | `Jenkinsfile.aux_db_init`       | ⬜     |
+| 7   | `aux_db_up`         | `Jenkinsfile.aux_db_up`         | ⬜     |
+| 8   | `aux_db_down`       | `Jenkinsfile.aux_db_down`       | ⬜     |
+| 9   | `aux_db_reset`      | `Jenkinsfile.aux_db_reset`      | ⬜     |
+| 10  | `aux_keyvaldb_up`   | `Jenkinsfile.aux_keyvaldb_up`   | ⬜     |
+| 11  | `aux_keyvaldb_down` | `Jenkinsfile.aux_keyvaldb_down` | ⬜     |
+| 12  | `aux_mq_up`         | `Jenkinsfile.aux_mq_up`         | ⬜     |
+| 13  | `aux_mq_down`       | `Jenkinsfile.aux_mq_down`       | ⬜     |
+
+### Phase 3: Management Database (Optional)
+
+| #   | Job Name                  | Jenkinsfile                           | Status |
+| --- | ------------------------- | ------------------------------------- | ------ |
+| 14  | `aux_management_db_init`  | `Jenkinsfile.aux_management_db_init`  | ⬜     |
+| 15  | `aux_management_db_up`    | `Jenkinsfile.aux_management_db_up`    | ⬜     |
+| 16  | `aux_management_db_down`  | `Jenkinsfile.aux_management_db_down`  | ⬜     |
+| 17  | `aux_management_db_reset` | `Jenkinsfile.aux_management_db_reset` | ⬜     |
+
+### Phase 4: Core Services (Srv Server)
+
+| #   | Job Name       | Jenkinsfile                | Status |
+| --- | -------------- | -------------------------- | ------ |
+| 18  | `srv_api_up`   | `Jenkinsfile.srv_api_up`   | ⬜     |
+| 19  | `srv_api_down` | `Jenkinsfile.srv_api_down` | ⬜     |
+| 20  | `srv_web_up`   | `Jenkinsfile.srv_web_up`   | ⬜     |
+| 21  | `srv_web_down` | `Jenkinsfile.srv_web_down` | ⬜     |
+
+### Phase 5: Management Services (Optional)
+
+| #   | Job Name                  | Jenkinsfile                           | Status |
+| --- | ------------------------- | ------------------------------------- | ------ |
+| 22  | `srv_management_api_up`   | `Jenkinsfile.srv_management_api_up`   | ⬜     |
+| 23  | `srv_management_api_down` | `Jenkinsfile.srv_management_api_down` | ⬜     |
+| 24  | `srv_management_web_up`   | `Jenkinsfile.srv_management_web_up`   | ⬜     |
+| 25  | `srv_management_web_down` | `Jenkinsfile.srv_management_web_down` | ⬜     |
+
+### Phase 6: Orchestration/Deployment Jobs
+
+| #   | Job Name                  | Jenkinsfile                                 | Status |
+| --- | ------------------------- | ------------------------------------------- | ------ |
+| 26  | `deploy_all`              | `Jenkinsfile.alpha_deploy_all`              | ⬜     |
+| 27  | `reset_db_and_deploy_all` | `Jenkinsfile.alpha_reset_db_and_deploy_all` | ⬜     |
+
+### Phase 7: All-Down Jobs (Convenience)
+
+| #   | Job Name       | Jenkinsfile                | Status |
+| --- | -------------- | -------------------------- | ------ |
+| 28  | `aux_all_down` | `Jenkinsfile.aux_all_down` | ⬜     |
+| 29  | `srv_all_down` | `Jenkinsfile.srv_all_down` | ⬜     |
+| 30  | `u_all_down`   | `Jenkinsfile.u_all_down`   | ⬜     |
+
+### Phase 8: Worker Jobs (Aux Server)
+
+| #   | Job Name                                                           | Jenkinsfile                                                                    | Status |
+| --- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------ |
+| 31  | `aux_workers_pull`                                                 | `Jenkinsfile.aux_workers_pull`                                                 | ⬜     |
+| 32  | `aux_workers_down`                                                 | `Jenkinsfile.aux_workers_down`                                                 | ⬜     |
+| 33  | `aux_workers_archive_all`                                          | `Jenkinsfile.aux_workers_archive_all`                                          | ⬜     |
+| 34  | `aux_workers_mq_rss_add`                                           | `Jenkinsfile.aux_workers_mq_rss_add`                                           | ⬜     |
+| 35  | `aux_workers_mq_rss_add_all`                                       | `Jenkinsfile.aux_workers_mq_rss_add_all`                                       | ⬜     |
+| 36  | `aux_workers_mq_rss_add_recently_updated_feeds_from_podcast_index` | `Jenkinsfile.aux_workers_mq_rss_add_recently_updated_feeds_from_podcast_index` | ⬜     |
+| 37  | `aux_workers_mq_rss_run_parsers`                                   | `Jenkinsfile.aux_workers_mq_rss_run_parsers`                                   | ⬜     |
+| 38  | `aux_workers_mq_rss_run_parsers_all`                               | `Jenkinsfile.aux_workers_mq_rss_run_parsers_all`                               | ⬜     |
+| 39  | `aux_workers_mq_rss_stop_parsers`                                  | `Jenkinsfile.aux_workers_mq_rss_stop_parsers`                                  | ⬜     |
+| 40  | `aux_workers_mq_rss_run_dlq_consumer`                              | `Jenkinsfile.aux_workers_mq_rss_run_dlq_consumer`                              | ⬜     |
+| 41  | `aux_workers_mq_rss_run_live_item_listener`                        | `Jenkinsfile.aux_workers_mq_rss_run_live_item_listener`                        | ⬜     |
+| 42  | `aux_workers_orm_feed_update_flag_status`                          | `Jenkinsfile.aux_workers_orm_feed_update_flag_status`                          | ⬜     |
+| 43  | `aux_workers_orm_on_demand_parser_event_delete_outdated`           | `Jenkinsfile.aux_workers_orm_on_demand_parser_event_delete_outdated`           | ⬜     |
+| 44  | `aux_workers_orm_on_demand_parser_event_generate_reports`          | `Jenkinsfile.aux_workers_orm_on_demand_parser_event_generate_reports`          | ⬜     |
+| 45  | `aux_workers_parser_rss_parse_feed`                                | `Jenkinsfile.aux_workers_parser_rss_parse_feed`                                | ⬜     |
+| 46  | `aux_workers_podcast_index_dead_feeds_delete_cache`                | `Jenkinsfile.aux_workers_podcast_index_dead_feeds_delete_cache`                | ⬜     |
+| 47  | `aux_workers_podcast_index_dead_feeds_flag_and_merge`              | `Jenkinsfile.aux_workers_podcast_index_dead_feeds_flag_and_merge`              | ⬜     |
+
+### Phase 9: Cleanup/Utility Jobs
+
+| #   | Job Name                  | Jenkinsfile                           | Status |
+| --- | ------------------------- | ------------------------------------- | ------ |
+| 48  | `aux_docker_prune_images` | `Jenkinsfile.aux_docker_prune_images` | ⬜     |
+| 49  | `srv_docker_prune_images` | `Jenkinsfile.srv_docker_prune_images` | ⬜     |
+| 50  | `aux_network_remove`      | `Jenkinsfile.aux_network_remove`      | ⬜     |
+| 51  | `srv_network_remove`      | `Jenkinsfile.srv_network_remove`      | ⬜     |
+
+---
+
+## Summary by Priority
+
+| Priority                                            | Jobs          | Count |
+| --------------------------------------------------- | ------------- | ----- |
+| **Critical** (must create to test basic deployment) | Phases 1-4, 6 | ~27   |
+| **Important** (for full functionality)              | Phases 5, 7-8 | ~20   |
+| **Nice to have** (maintenance/cleanup)              | Phase 9       | ~4    |
+
+---
+
+## Minimum Viable Set for Testing
+
+If you want to test the basic deployment pipeline first, create these 15 jobs in order:
+
+| #   | Job Name             | Purpose                       |
+| --- | -------------------- | ----------------------------- |
+| 1   | `aux_network_create` | Create Docker network on aux  |
+| 2   | `srv_network_create` | Create Docker network on srv  |
+| 3   | `aux_ops_git_pull`   | Pull latest code on aux       |
+| 4   | `srv_ops_git_pull`   | Pull latest code on srv       |
+| 5   | `aux_db_init`        | Initialize database container |
+| 6   | `aux_db_up`          | Start database                |
+| 7   | `aux_keyvaldb_up`    | Start Redis                   |
+| 8   | `aux_mq_up`          | Start message queue           |
+| 9   | `srv_api_up`         | Start API server              |
+| 10  | `srv_web_up`         | Start web app                 |
+| 11  | `deploy_all`         | Full deployment orchestration |
+| 12  | `aux_db_down`        | Stop database                 |
+| 13  | `srv_api_down`       | Stop API                      |
+| 14  | `srv_web_down`       | Stop web app                  |
+| 15  | `aux_all_down`       | Stop all on aux               |
+
+---
+
+## Job Creation Method
+
+Each job is created in Jenkins using the `scm-job.xml` template with the script path replaced:
+
+1. In Jenkins, navigate to `pipelines/alpha` folder
+2. Create new Pipeline job with name `<job_suffix>`
+3. Configure Pipeline from SCM:
+   - Repository: `https://github.com/podverse/podverse.git`
+   - Branch: `*/v5-develop`
+   - Script Path: `pipelines/jenkins/alpha/Jenkinsfile.<job_suffix>`
+   - Enable sparse checkout (same paths as in `scm-job.xml`)
+
+Or use Jenkins CLI / Job DSL to automate creation from the template.
+
+---
+
+## Notes
+
+- All Jenkinsfiles are located in `podverse/pipelines/jenkins/alpha/`
+- The `scm-job.xml` template uses sparse checkout for: `pipelines/jenkins/`, `infra/docker/`, `infra/config/`, `scripts/`, `Makefile`, `Makefile.alpha`
+- These jobs will use the monorepo paths (`/opt/podverse/infra/config/alpha/`) configured via Ansible

--- a/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/DEPLOYMENT-TESTING-CHECKLIST.md
+++ b/.llm/plans/completed/monorepo-migration/16-jenkins-ansible-monorepo/DEPLOYMENT-TESTING-CHECKLIST.md
@@ -1,0 +1,205 @@
+# Alpha Monorepo Migration - Deployment Testing Checklist
+
+This checklist should be completed before considering the migration complete. It verifies that all changes work correctly in the actual alpha environment.
+
+## Pre-Deployment Verification
+
+### Ansible Configuration
+
+- [ ] Verify `podverse_monorepo` role syntax:
+  ```bash
+  cd podverse-ansible
+  ansible-playbook --syntax-check podverse-alpha-srv.yaml
+  ansible-playbook --syntax-check podverse-alpha-aux.yaml
+  ```
+
+- [ ] Verify all alpha config role file paths exist:
+  ```bash
+  # From podverse-ansible directory:
+  find roles/podverse_alpha_*/files/opt/podverse/infra/config/alpha -type f
+  # Should show 8 files (7 .env files + 1 firebase-admin.json)
+  ```
+
+- [ ] Confirm no `podverse-ops` references in alpha roles:
+  ```bash
+  grep -r "podverse-ops" roles/podverse_alpha_* roles/podverse_monorepo podverse-alpha-*.yaml
+  # Should return no results
+  ```
+
+### Jenkins Configuration
+
+- [ ] Verify `scm-job.xml` has sparse checkout configured:
+  ```bash
+  # From podverse-ansible directory:
+  grep -A 10 "SparseCheckoutPaths" ../podverse/pipelines/jenkins/alpha/scm-job.xml
+  # Or from podverse directory:
+  grep -A 10 "SparseCheckoutPaths" pipelines/jenkins/alpha/scm-job.xml
+  ```
+
+- [ ] Confirm Jenkinsfiles reference monorepo paths:
+  ```bash
+  # From podverse-ansible directory:
+  grep -r "/opt/podverse" ../podverse/pipelines/jenkins/alpha/Jenkinsfile.* | head -5
+  # Or from podverse directory:
+  grep -r "/opt/podverse" pipelines/jenkins/alpha/Jenkinsfile.* | head -5
+  # Should show /opt/podverse references, not /opt/podverse-ops
+  ```
+
+## Deployment Testing (Dry-Run)
+
+### Step 1: Ansible Playbook Dry-Run
+
+- [ ] Run alpha-srv playbook in check mode:
+  ```bash
+  # From podverse-ansible directory:
+  ansible-playbook --check --diff podverse-alpha-srv.yaml
+  ```
+  - Verify it would create `/opt/podverse` directory
+  - Verify it would clone monorepo with sparse checkout
+  - Verify it would deploy configs to `/opt/podverse/infra/config/alpha/`
+
+- [ ] Run alpha-aux playbook in check mode:
+  ```bash
+  # From podverse-ansible directory:
+  ansible-playbook --check --diff podverse-alpha-aux.yaml
+  ```
+  - Verify it would create `/opt/podverse` directory
+  - Verify it would clone monorepo with sparse checkout
+  - Verify it would deploy configs to `/opt/podverse/infra/config/alpha/`
+
+### Step 2: Verify Sparse Checkout
+
+After running playbooks (or on existing server):
+
+- [ ] SSH to alpha-srv and verify sparse checkout:
+  ```bash
+  ssh alpha-srv
+  ls -la /opt/podverse/
+  # Should show: infra/, pipelines/, scripts/, Makefile, Makefile.alpha
+  # Should NOT show: apps/, packages/, etc.
+  ```
+
+- [ ] Verify sparse checkout paths:
+  ```bash
+  cat /opt/podverse/.git/info/sparse-checkout
+  # Should list: pipelines/jenkins/, infra/docker/, infra/config/, scripts/, Makefile, Makefile.alpha
+  ```
+
+- [ ] Verify config files exist:
+  ```bash
+  ls -la /opt/podverse/infra/config/alpha/
+  # Should show all alpha .env files
+  ```
+
+### Step 3: Jenkins Job Testing
+
+- [ ] Import Jenkins jobs (if not already done):
+  ```bash
+  # From podverse-ansible directory:
+  cd ../podverse/pipelines/jenkins/alpha
+  bash import.sh ~/.jenkins-api-token
+  # Or from podverse directory:
+  cd pipelines/jenkins/alpha
+  bash import.sh ~/.jenkins-api-token
+  ```
+
+- [ ] Verify Jenkins workspace structure:
+  - Check Jenkins agent workspace at `/opt/podverse`
+  - Confirm sparse checkout is working (only deployment dirs present)
+  - Verify no `podverse-ops` directory exists
+
+- [ ] Test a simple pipeline:
+  - Run `srv_ops_git_pull` job
+  - Verify it pulls from monorepo successfully
+  - Check that paths resolve correctly
+
+### Step 4: Makefile Target Testing
+
+- [ ] Test Makefile.alpha targets can find configs:
+  ```bash
+  ssh alpha-srv
+  cd /opt/podverse
+  make -f Makefile.alpha alpha_validate_init
+  # Should verify all config files exist at new paths
+  ```
+
+- [ ] Test a service deployment:
+  ```bash
+  # On alpha-srv:
+  ssh alpha-srv
+  cd /opt/podverse
+  make -f Makefile.alpha alpha_api_up
+  # Should start API using configs from /opt/podverse/infra/config/alpha/
+  ```
+
+## Full Deployment Test
+
+### Step 5: End-to-End Deployment
+
+- [ ] Run full alpha deployment via Jenkins:
+  - Execute `alpha_deploy_all` pipeline
+  - Monitor logs for any path-related errors
+  - Verify all services start successfully
+
+- [ ] Verify services are running:
+  ```bash
+  # On alpha-srv
+  docker ps | grep podverse-api
+  docker ps | grep podverse-web
+  
+  # On alpha-aux
+  docker ps | grep podverse-db
+  docker ps | grep podverse-mq
+  docker ps | grep podverse-workers
+  ```
+
+- [ ] Test API endpoints:
+  ```bash
+  curl https://api.alpha.podverse.fm/health
+  curl https://alpha.podverse.fm
+  ```
+
+### Step 6: Verify No Production Impact
+
+- [ ] Confirm production/sandbox unchanged:
+  ```bash
+  # Production should still use /opt/podverse-ops
+  ssh prod-srv
+  ls -la /opt/podverse-ops  # Should exist
+  ls -la /opt/podverse      # Should NOT exist (or be different)
+  ```
+
+- [ ] Verify production playbooks unchanged:
+  ```bash
+  cd podverse-ansible
+  grep -r "podverse_monorepo" podverse-prod-*.yaml
+  # Should return no results
+  ```
+
+## Rollback Plan
+
+If issues are discovered:
+
+- [ ] Revert alpha playbooks to use `podverse_ops` role
+- [ ] Revert alpha config roles to deploy to `/opt/podverse-ops/config/`
+- [ ] Move role files back to old hierarchy
+- [ ] Update Jenkins jobs to use `podverse-ops` repo
+
+## Success Criteria
+
+All of the following must pass:
+
+- ✅ Ansible playbooks deploy successfully
+- ✅ Sparse checkout works correctly
+- ✅ Config files land at `/opt/podverse/infra/config/alpha/`
+- ✅ Jenkins pipelines can access all required files
+- ✅ Makefile targets work with new paths
+- ✅ All services start and run correctly
+- ✅ No production/sandbox environments affected
+- ✅ No `podverse-ops` references in alpha code paths
+
+## Notes
+
+- This migration is **alpha-only** - production and sandbox continue using `podverse-ops`
+- The `podverse_ops` role remains unchanged for production/sandbox compatibility
+- All alpha-specific paths are under `/opt/podverse/infra/config/alpha/` to avoid conflicts

--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ validate_docker: validate
 # Include Environment-Specific Makefiles
 # ==========================================
 
-include Makefile.local
+-include Makefile.local
 include Makefile.alpha

--- a/pipelines/jenkins/alpha/README.md
+++ b/pipelines/jenkins/alpha/README.md
@@ -2,6 +2,22 @@
 
 This directory contains tools for importing Jenkins pipeline jobs from this repository into a Jenkins server.
 
+## Monorepo Structure
+
+These Jenkins pipelines use the `podverse` monorepo with **sparse checkout** to minimize server disk usage. Only deployment-related directories are checked out:
+
+- `pipelines/jenkins/` - Jenkins pipeline definitions
+- `infra/docker/` - Docker Compose configurations
+- `infra/config/` - Environment configuration files
+- `scripts/` - Deployment scripts
+- `Makefile` and `Makefile.alpha` - Make targets for deployment
+
+The Jenkins job template (`scm-job.xml`) is configured to:
+- Clone from `https://github.com/podverse/podverse.git`
+- Use sparse checkout (only the paths listed above)
+- Checkout the `v5-develop` branch by default
+- Store the checkout at `/opt/podverse` on the Jenkins agent
+
 ## Prerequisites
 
 ### 1. Download Jenkins CLI
@@ -88,6 +104,17 @@ To modify the job template:
 2. Keep the `REPLACE_SCRIPT_PATH` placeholder intact
 3. Adjust other Jenkins job settings as needed
 
+## Path References
+
+All Jenkins pipelines reference paths under `/opt/podverse`:
+
+- **Docker Compose configs**: `/opt/podverse/infra/docker/alpha/`
+- **Environment configs**: `/opt/podverse/infra/config/alpha/`
+- **Scripts**: `/opt/podverse/scripts/`
+- **Makefiles**: `/opt/podverse/Makefile.alpha`
+
+These paths are set up by the `podverse_monorepo` Ansible role during server provisioning.
+
 ## Troubleshooting
 
 **Error: Unable to access jarfile jenkins-cli.jar**
@@ -100,3 +127,8 @@ To modify the job template:
 - Verify your credentials file format is correct: `username:api_token` (single line, no spaces)
 - Ensure your API token is valid and hasn't expired
 - Check that your user has permissions to create jobs in Jenkins
+
+**Pipeline fails: "file not found" errors**
+- Verify sparse checkout is working: check that `/opt/podverse/infra/docker/alpha/` exists on the Jenkins agent
+- Ensure the `podverse_monorepo` Ansible role has been run on the server
+- Check that the Jenkins job SCM configuration includes all required sparse checkout paths

--- a/pipelines/jenkins/alpha/scm-job.xml
+++ b/pipelines/jenkins/alpha/scm-job.xml
@@ -19,10 +19,34 @@
       </branches>
       <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
       <submoduleCfg class="list"/>
-      <extensions/>
+      <extensions>
+        <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+        <hudson.plugins.git.extensions.impl.SparseCheckoutPaths>
+          <sparseCheckoutPaths>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>pipelines/jenkins/</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>infra/docker/</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>infra/config/</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>scripts/</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>Makefile</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+            <hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+              <path>Makefile.alpha</path>
+            </hudson.plugins.git.extensions.impl.SparseCheckoutPath>
+          </sparseCheckoutPaths>
+        </hudson.plugins.git.extensions.impl.SparseCheckoutPaths>
+      </extensions>
     </scm>
     <scriptPath>REPLACE_SCRIPT_PATH</scriptPath>
-    <lightweight>true</lightweight>
+    <lightweight>false</lightweight>
   </definition>
   <triggers/>
   <disabled>false</disabled>


### PR DESCRIPTION
- Merged multiple deployment plans for the alpha environment into a single comprehensive plan, streamlining the migration process to the monorepo structure.
- Updated the Makefile to include the new deployment plan and ensure proper integration with the alpha-specific configurations.
- Adjusted paths and documentation to reflect the new monorepo layout, enhancing clarity for future deployments. #2

## Description

<!-- What does this PR do? -->

## Related Issue

<!-- Link to GitHub issue: Fixes #123 or Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code compiles without errors
- [ ] Linting passes (`npm run lint`)
- [ ] I have tested my changes
- [ ] Documentation updated if needed

## LLM Development (Optional)

If you used AI assistance (Cursor, Claude, etc.) for this PR:

- [ ] I kept my LLM history updated in `.llm/history/active/`

> **Note**: History files are automatically moved to `completed/` when this PR is merged.
> See [LLM Development docs](.llm/README.md) for more information.

## CI

> **Note**: A maintainer will comment `/test` to run CI checks on this PR.

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
