### PR TITLE
feat: add remote Kubernetes GitOps documentation and update paths

### DIFF
--- a/.llm/history/active/podverse-alpha-remote-gitops/podverse-alpha-remote-gitops-part-01.md
+++ b/.llm/history/active/podverse-alpha-remote-gitops/podverse-alpha-remote-gitops-part-01.md
@@ -1,0 +1,39 @@
+### Session 1 - 2026-04-25
+
+#### Prompt (Developer)
+
+execute
+
+#### Key Decisions
+
+- Execute the approved deploy-readiness plan end-to-end.
+- Use `newTag: staging` for Podverse alpha app images in the GitOps repo.
+- Default remote base policy for GitOps overlays uses `?ref=staging`.
+- Podverse documentation updates must be domain-agnostic for open source usage.
+
+#### Files Modified
+
+- .llm/history/active/podverse-alpha-remote-gitops/podverse-alpha-remote-gitops-part-01.md
+- docs/development/REMOTE-K8S-GITOPS.md
+- docs/operations/ALPHA-DEPLOYMENT.md
+- infra/k8s/README.md
+- infra/k8s/K8S.md
+- infra/k8s/alpha-application.yaml
+- infra/k8s/alpha/api/kustomization.yaml
+- infra/k8s/alpha/common/kustomization.yaml
+- infra/k8s/alpha/cron/kustomization.yaml
+- infra/k8s/alpha/db/kustomization.yaml
+- infra/k8s/alpha/keyvaldb/kustomization.yaml
+- infra/k8s/alpha/management-web/kustomization.yaml
+- infra/k8s/alpha/mq/kustomization.yaml
+- infra/k8s/alpha/web/kustomization.yaml
+- infra/k8s/alpha/apps/api.yaml
+- infra/k8s/alpha/apps/common.yaml
+- infra/k8s/alpha/apps/cron.yaml
+- infra/k8s/alpha/apps/db.yaml
+- infra/k8s/alpha/apps/keyvaldb.yaml
+- infra/k8s/alpha/apps/management-db.yaml
+- infra/k8s/alpha/apps/management-web.yaml
+- infra/k8s/alpha/apps/mq.yaml
+- infra/k8s/alpha/apps/web.yaml
+- infra/k8s/alpha/apps/workers.yaml

--- a/docs/development/REMOTE-K8S-GITOPS.md
+++ b/docs/development/REMOTE-K8S-GITOPS.md
@@ -1,0 +1,118 @@
+# Remote Kubernetes (GitOps)
+
+Use this guide to deploy Podverse to a remote Kubernetes cluster with Argo CD and a separate GitOps repository.
+
+This document is intentionally domain-agnostic for open source use:
+
+- Use placeholders like `<gitops-repo>`, `<namespace>`, `<env>`, `api.example.com`, `app.example.com`.
+- Keep operator-specific hostnames, private repo URLs, and local runbooks in your GitOps repository docs.
+
+## Scope and model
+
+- Podverse repository:
+  - Builds/publishes images (`staging` branch -> `X.Y.Z-staging.N` + floating `:staging`)
+  - Owns shared base manifests under `infra/k8s/base/`
+- GitOps repository:
+  - Owns environment overlays (`apps/podverse-<env>/`)
+  - Owns Argo `Application` manifests (`argocd/podverse-<env>/`)
+  - Owns environment hostnames, ingress rules, TLS issuer selection, and encrypted secrets
+
+## Defaults
+
+- **Image tags (alpha):** set Podverse app images to `newTag: "staging"` in GitOps overlays.
+- **Remote base refs (alpha):** set Podverse remote bases to `?ref=staging` by default.
+- **Reproducible fallback:** pin all Podverse app images and remote base `?ref=` to the same immutable `X.Y.Z-staging.N` when needed.
+
+## Dry-run first workflow
+
+Before writing cluster state or committing changes:
+
+1. Render and compile overlays locally:
+
+```bash
+kubectl kustomize apps/podverse-<env>/common --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/api --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/web --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/management-api --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/management-web --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/workers --load-restrictor LoadRestrictionsNone >/dev/null
+kubectl kustomize apps/podverse-<env>/cron --load-restrictor LoadRestrictionsNone >/dev/null
+```
+
+2. Validate Argo and app YAML before apply:
+
+```bash
+kubectl apply --dry-run=server -f argocd/apps/<project>.yaml
+kubectl apply --dry-run=server -f argocd/podverse-<env>/
+```
+
+3. Validate encrypted secrets before apply:
+
+```bash
+sops -d secrets/<namespace>/<secret>.enc.yaml | kubectl apply --dry-run=server -n <namespace> -f -
+```
+
+## GitOps overlay contract
+
+In your GitOps repo overlays:
+
+- `resources:` remote bases use:
+  - `https://github.com/podverse/podverse//infra/k8s/base/<component>?ref=staging`
+- Podverse app `images[].newTag` use:
+  - `staging` for alpha/preprod drift-forward behavior
+
+Keep this contract consistent across `api`, `web`, `management-api`, `management-web`, `workers`, and `cron`.
+
+## Argo CD source contract
+
+In your GitOps repo Argo `Application` manifests:
+
+- `spec.source.repoURL` points to **your GitOps repository**
+- `spec.source.targetRevision` points to your tracked branch (commonly `main`)
+- `spec.source.path` points to your local GitOps overlay path (`apps/podverse-<env>/<component>`)
+
+Do not confuse:
+
+- `targetRevision` for the GitOps repo branch (usually `main`)
+- `?ref=` for remote Podverse base manifests (default `staging` in this guide)
+
+## Recommended sync order
+
+Sync in dependency order:
+
+1. `common`
+2. `db`, `keyvaldb`, `mq`
+3. `api`, `management-api`, `workers`, `cron`
+4. `web`, `management-web`
+
+## Verification checklist
+
+- Pods are ready:
+
+```bash
+kubectl -n <namespace> get pods
+```
+
+- Services and ingress exist:
+
+```bash
+kubectl -n <namespace> get svc,ingress
+```
+
+- Public endpoints respond (replace placeholders):
+
+```bash
+curl -sI https://api.example.com/v1/health
+```
+
+## Related docs
+
+- [PUBLISH](../operations/PUBLISH.md)
+- [ALPHA-DEPLOYMENT](../operations/ALPHA-DEPLOYMENT.md)
+- [infra/k8s/README](../../infra/k8s/README.md)
+
+## Documentation guardrails (must pass)
+
+- No operator-specific domains or repo URLs in this file.
+- Use placeholders (`example.com`, `<env>`, `<namespace>`, `<gitops-repo>`).
+- Keep environment-specific values in operator GitOps docs, not Podverse OSS docs.

--- a/docs/operations/ALPHA-DEPLOYMENT.md
+++ b/docs/operations/ALPHA-DEPLOYMENT.md
@@ -2,6 +2,10 @@
 
 This document describes how to deploy to the alpha environment for testing.
 
+For remote Kubernetes + Argo CD deployments with a separate GitOps repository, use
+[REMOTE-K8S-GITOPS](../development/REMOTE-K8S-GITOPS.md). This guide focuses on image
+publish and local/server alpha workflows from this repository.
+
 ## Overview
 
 The alpha environment is a pre-production testing environment. Docker images are built and pushed to GitHub Container Registry (GHCR) when:
@@ -405,6 +409,7 @@ gh run rerun <run-id> --failed
 ## Related Documentation
 
 - [Publish: branch → semver → floating tag](PUBLISH.md)
+- [Remote Kubernetes (GitOps)](../development/REMOTE-K8S-GITOPS.md)
 - [Branch Protection Rules](../repo-management/BRANCH-PROTECTION.md)
 - [Secrets Configuration](SECRETS.md)
 - [Quick Start Guide](../QUICKSTART.md)

--- a/infra/k8s/K8S.md
+++ b/infra/k8s/K8S.md
@@ -2,6 +2,9 @@
 
 Deployment scripts and Kubernetes manifests for the Podverse ecosystem.
 
+For a domain-agnostic remote-cluster guide that uses a separate GitOps repository, see
+[`docs/development/REMOTE-K8S-GITOPS.md`](../../docs/development/REMOTE-K8S-GITOPS.md).
+
 ## Architecture Overview
 
 This repository uses a GitOps workflow (via ArgoCD) to manage the Podverse infrastructure on a K3s cluster.
@@ -20,7 +23,7 @@ This repository uses a GitOps workflow (via ArgoCD) to manage the Podverse infra
 
 ## Prerequisites
 
-Before deploying the Application manifests (in `k8s/alpha`), ensure the following Infrastructure is running:
+Before deploying the Application manifests (in `infra/k8s/alpha`), ensure the following Infrastructure is running:
 
 1.  **K3s Cluster**: Up and running (e.g., on NixOS/Proxmox).
 2.  **Cert-Manager**: Installed in `cert-manager` namespace.
@@ -32,7 +35,7 @@ Before deploying the Application manifests (in `k8s/alpha`), ensure the followin
 
 ## Directory Structure
 
-- `k8s/`
+- `infra/k8s/`
   - `system/`: Cluster-wide configs (Traefik defaults, etc.).
   - `alpha/`: Manifests for the Alpha environment.
     - `00-namespace.yaml`: Isolation boundary.
@@ -43,7 +46,7 @@ Before deploying the Application manifests (in `k8s/alpha`), ensure the followin
 
 ### 1. Generate Secrets
 
-We use SOPS to encrypt secrets. Run the helper scripts in `k8s/scripts/` to generate the required encrypted files.
+We use SOPS to encrypt secrets. Run the helper scripts in `infra/k8s/scripts/` to generate the required encrypted files.
 
 **Requirements Checklist:**
 
@@ -75,38 +78,38 @@ Before running the scripts, ensure you have the following ready:
 
 ```bash
 # Run each script and follow the prompts
-bash ./k8s/scripts/create_db_secret.sh
-bash ./k8s/scripts/create_mq_secret.sh
-bash ./k8s/scripts/create_api_secret.sh
-bash ./k8s/scripts/create_workers_secret.sh
-bash ./k8s/scripts/create_firebase_secret.sh
+bash ./infra/k8s/scripts/create_db_secret.sh
+bash ./infra/k8s/scripts/create_mq_secret.sh
+bash ./infra/k8s/scripts/create_api_secret.sh
+bash ./infra/k8s/scripts/create_workers_secret.sh
+bash ./infra/k8s/scripts/create_firebase_secret.sh
 ```
 
 **Apply**
 
 ```bash
 kubectl create namespace podverse-alpha
-kubectl apply -f k8s/system/traefik-config.yaml
+kubectl apply -f infra/k8s/system/traefik-config.yaml
 
 
-for file in k8s/secrets/podverse-alpha-*-opaque.enc.yaml; do
+for file in infra/k8s/secrets/podverse-alpha-*-opaque.enc.yaml; do
     sops -d "$file" | kubectl apply -f -
 done
 
-kubectl apply -f k8s/alpha-application.yaml
+kubectl apply -f infra/k8s/alpha-application.yaml
 
 ```
 
 ```fish
 kubectl create namespace podverse-alpha
-kubectl apply -f k8s/system/traefik-config.yaml
+kubectl apply -f infra/k8s/system/traefik-config.yaml
 
 
-for file in k8s/secrets/podverse-alpha-*-opaque.enc.yaml
+for file in infra/k8s/secrets/podverse-alpha-*-opaque.enc.yaml
     sops -d $file | kubectl apply -f -
 end
 
-kubectl apply -f k8s/alpha-application.yaml
+kubectl apply -f infra/k8s/alpha-application.yaml
 
 
 ```
@@ -116,21 +119,21 @@ kubectl apply -f k8s/alpha-application.yaml
 Use Kustomize to render overlays locally, matching what ArgoCD applies. Because bases live outside the overlay folders, include the relaxed load restrictor flag.
 
 ```bash
-kustomize build --load-restrictor LoadRestrictionsNone k8s/alpha/workers/
+kustomize build --load-restrictor LoadRestrictionsNone infra/k8s/alpha/workers/
 ```
 
-Other overlays render the same way (e.g., `k8s/alpha/api`, `k8s/alpha/web`, `k8s/alpha/db`). Add `| kubectl apply -f - --dry-run=client` to validate locally before pushing to Git.
+Other overlays render the same way (e.g., `infra/k8s/alpha/api`, `infra/k8s/alpha/web`, `infra/k8s/alpha/db`). Add `| kubectl apply -f - --dry-run=client` to validate locally before pushing to Git.
 
 ## ArgoCD bootstrap (App of Apps)
 
-- Update `repoURL` and `targetRevision` in [k8s/alpha-application.yaml](k8s/alpha-application.yaml) if deploying from a fork or different branch.
-- Apply the root application once: `kubectl apply -f k8s/alpha-application.yaml`. ArgoCD will create child apps for common, api, web, db, mq, workers, and cron.
+- Update `repoURL` and `targetRevision` in [infra/k8s/alpha-application.yaml](alpha-application.yaml) if deploying from a fork or different branch.
+- Apply the root application once: `kubectl apply -f infra/k8s/alpha-application.yaml`. ArgoCD will create child apps for common, api, web, db, mq, workers, and cron.
 - Leave automated sync, prune, and self-heal enabled (already configured in manifests).
 
 ## Secrets and SOPS
 
-- Encrypted secrets live under [k8s/secrets/](k8s/secrets/). Decrypt with `sops -d` when applying manually.
-- Helper scripts in [k8s/scripts/](k8s/scripts/README.md) generate secrets for DB, MQ, API, workers, Firebase, and Valkey. They assume SOPS keys are available and `nix develop` provides required binaries.
+- Encrypted secrets live under [infra/k8s/secrets/](secrets/). Decrypt with `sops -d` when applying manually.
+- Helper scripts in [infra/k8s/scripts/](scripts/README.md) generate secrets for DB, MQ, API, workers, Firebase, and Valkey. They assume SOPS keys are available and `nix develop` provides required binaries.
 - Never commit decrypted secrets; ArgoCD consumes the encrypted files directly.
 
 ## Linting and Formatting
@@ -188,7 +191,7 @@ Instead of manually managing individual resources (Deployments, Services, etc.) 
 ## Directory Structure
 
 ```text
-k8s/
+infra/k8s/
 ├── alpha-application.yaml      # ROOT APP: The entry point for ArgoCD
 ├── alpha/                      # The actual infrastructure and application code
 │   ├── apps/                   # CHILD APPS: ArgoCD Application definitions

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -2,6 +2,9 @@
 
 Deployment scripts and Kubernetes manifests for the Podverse ecosystem.
 
+For a domain-agnostic remote-cluster guide that uses a separate GitOps repository, see
+[`docs/development/REMOTE-K8S-GITOPS.md`](../../docs/development/REMOTE-K8S-GITOPS.md).
+
 ## Architecture Overview
 
 This repository uses a GitOps workflow (via ArgoCD) to manage the Podverse infrastructure on a K3s cluster.
@@ -20,7 +23,7 @@ This repository uses a GitOps workflow (via ArgoCD) to manage the Podverse infra
 
 ## Prerequisites
 
-Before deploying the Application manifests (in `k8s/alpha`), ensure the following Infrastructure is running:
+Before deploying the Application manifests (in `infra/k8s/alpha`), ensure the following Infrastructure is running:
 
 1.  **K3s Cluster**: Up and running (e.g., on NixOS/Proxmox).
 2.  **Cert-Manager**: Installed in `cert-manager` namespace.
@@ -32,7 +35,7 @@ Before deploying the Application manifests (in `k8s/alpha`), ensure the followin
 
 ## Directory Structure
 
-- `k8s/`
+- `infra/k8s/`
   - `system/`: Cluster-wide configs (Traefik defaults, etc.).
   - `alpha/`: Manifests for the Alpha environment.
     - `00-namespace.yaml`: Isolation boundary.
@@ -43,7 +46,7 @@ Before deploying the Application manifests (in `k8s/alpha`), ensure the followin
 
 ### 1. Generate Secrets
 
-We use SOPS to encrypt secrets. Run the helper scripts in `k8s/scripts/` to generate the required encrypted files.
+We use SOPS to encrypt secrets. Run the helper scripts in `infra/k8s/scripts/` to generate the required encrypted files.
 
 **Requirements Checklist:**
 
@@ -83,39 +86,39 @@ Before running the scripts, ensure you have the following ready:
 
 ```bash
 # Run each script and follow the prompts
-bash ./k8s/scripts/create_db_secret.sh
-bash ./k8s/scripts/create_management_db_secret.sh
-bash ./k8s/scripts/create_mq_secret.sh
-bash ./k8s/scripts/create_api_secret.sh
-bash ./k8s/scripts/create_workers_secret.sh
-bash ./k8s/scripts/create_firebase_secret.sh
+bash ./infra/k8s/scripts/create_db_secret.sh
+bash ./infra/k8s/scripts/create_management_db_secret.sh
+bash ./infra/k8s/scripts/create_mq_secret.sh
+bash ./infra/k8s/scripts/create_api_secret.sh
+bash ./infra/k8s/scripts/create_workers_secret.sh
+bash ./infra/k8s/scripts/create_firebase_secret.sh
 ```
 
 **Apply**
 
 ```bash
 kubectl create namespace podverse-alpha
-kubectl apply -f k8s/system/traefik-config.yaml
+kubectl apply -f infra/k8s/system/traefik-config.yaml
 
 
-for file in k8s/secrets/podverse-alpha-*-opaque.enc.yaml; do
+for file in infra/k8s/secrets/podverse-alpha-*-opaque.enc.yaml; do
     sops -d "$file" | kubectl apply -f -
 done
 
-kubectl apply -f k8s/alpha-application.yaml
+kubectl apply -f infra/k8s/alpha-application.yaml
 
 ```
 
 ```fish
 kubectl create namespace podverse-alpha
-kubectl apply -f k8s/system/traefik-config.yaml
+kubectl apply -f infra/k8s/system/traefik-config.yaml
 
 
-for file in k8s/secrets/podverse-alpha-*-opaque.enc.yaml
+for file in infra/k8s/secrets/podverse-alpha-*-opaque.enc.yaml
     sops -d $file | kubectl apply -f -
 end
 
-kubectl apply -f k8s/alpha-application.yaml
+kubectl apply -f infra/k8s/alpha-application.yaml
 
 
 ```
@@ -125,21 +128,21 @@ kubectl apply -f k8s/alpha-application.yaml
 Use Kustomize to render overlays locally, matching what ArgoCD applies. Because bases live outside the overlay folders, include the relaxed load restrictor flag.
 
 ```bash
-kustomize build --load-restrictor LoadRestrictionsNone k8s/alpha/workers/
+kustomize build --load-restrictor LoadRestrictionsNone infra/k8s/alpha/workers/
 ```
 
-Other overlays render the same way (e.g., `k8s/alpha/api`, `k8s/alpha/web`, `k8s/alpha/db`). Add `| kubectl apply -f - --dry-run=client` to validate locally before pushing to Git.
+Other overlays render the same way (e.g., `infra/k8s/alpha/api`, `infra/k8s/alpha/web`, `infra/k8s/alpha/db`). Add `| kubectl apply -f - --dry-run=client` to validate locally before pushing to Git.
 
 ## ArgoCD bootstrap (App of Apps)
 
-- Update `repoURL` and `targetRevision` in [k8s/alpha-application.yaml](k8s/alpha-application.yaml) if deploying from a fork or different branch.
-- Apply the root application once: `kubectl apply -f k8s/alpha-application.yaml`. ArgoCD will create child apps for common, api, web, db, mq, workers, and cron.
+- Update `repoURL` and `targetRevision` in [infra/k8s/alpha-application.yaml](alpha-application.yaml) if deploying from a fork or different branch.
+- Apply the root application once: `kubectl apply -f infra/k8s/alpha-application.yaml`. ArgoCD will create child apps for common, api, web, db, mq, workers, and cron.
 - Leave automated sync, prune, and self-heal enabled (already configured in manifests).
 
 ## Secrets and SOPS
 
-- Encrypted secrets live under [k8s/secrets/](k8s/secrets/). Decrypt with `sops -d` when applying manually.
-- Helper scripts in [k8s/scripts/](k8s/scripts/README.md) generate secrets for DB, MQ, API, workers, Firebase, and Valkey. They assume SOPS keys are available and `nix develop` provides required binaries.
+- Encrypted secrets live under [infra/k8s/secrets/](secrets/). Decrypt with `sops -d` when applying manually.
+- Helper scripts in [infra/k8s/scripts/](scripts/README.md) generate secrets for DB, MQ, API, workers, Firebase, and Valkey. They assume SOPS keys are available and `nix develop` provides required binaries.
 - Never commit decrypted secrets; ArgoCD consumes the encrypted files directly.
 
 ## Linting and Formatting
@@ -197,7 +200,7 @@ Instead of manually managing individual resources (Deployments, Services, etc.) 
 ## Directory Structure
 
 ```text
-k8s/
+infra/k8s/
 ├── alpha-application.yaml      # ROOT APP: The entry point for ArgoCD
 ├── alpha/                      # The actual infrastructure and application code
 │   ├── apps/                   # CHILD APPS: ArgoCD Application definitions

--- a/infra/k8s/alpha-application.yaml
+++ b/infra/k8s/alpha-application.yaml
@@ -17,7 +17,7 @@ spec:
     targetRevision: staging
 
     # This path points to where the "Child" App manifests are stored
-    path: k8s/alpha/apps
+    path: infra/k8s/alpha/apps
 
     directory:
       recurse: true

--- a/infra/k8s/alpha/api/kustomization.yaml
+++ b/infra/k8s/alpha/api/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/api?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/api?ref=staging
 
 # 2. Namespace (optional, ensures all resources are in this namespace)
 namespace: podverse-alpha

--- a/infra/k8s/alpha/apps/api.yaml
+++ b/infra/k8s/alpha/apps/api.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the API manifests (Deployment, Service, ConfigMap)
-    path: k8s/alpha/api
+    path: infra/k8s/alpha/api
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/common.yaml
+++ b/infra/k8s/alpha/apps/common.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the actual manifests for namespace and ingress
-    path: k8s/alpha/common
+    path: infra/k8s/alpha/common
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/cron.yaml
+++ b/infra/k8s/alpha/apps/cron.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the Cron manifests (CronJobs for reports, archiving, etc.)
-    path: k8s/alpha/cron
+    path: infra/k8s/alpha/cron
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/db.yaml
+++ b/infra/k8s/alpha/apps/db.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the database manifests (StatefulSet, Service, etc.)
-    path: k8s/alpha/db
+    path: infra/k8s/alpha/db
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/keyvaldb.yaml
+++ b/infra/k8s/alpha/apps/keyvaldb.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the valkey manifests (Deployment, Service, ConfigMap)
-    path: k8s/alpha/keyvaldb
+    path: infra/k8s/alpha/keyvaldb
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/management-db.yaml
+++ b/infra/k8s/alpha/apps/management-db.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://github.com/podverse/podverse.git
     targetRevision: staging
-    path: k8s/alpha/db
+    path: infra/k8s/alpha/db
   destination:
     server: https://kubernetes.default.svc
     namespace: podverse-alpha

--- a/infra/k8s/alpha/apps/management-web.yaml
+++ b/infra/k8s/alpha/apps/management-web.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the Management Web manifests (Deployment, Service, ConfigMap)
-    path: k8s/alpha/management-web
+    path: infra/k8s/alpha/management-web
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/mq.yaml
+++ b/infra/k8s/alpha/apps/mq.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the message queue manifests (StatefulSet, Service, Provisioning Job)
-    path: k8s/alpha/mq
+    path: infra/k8s/alpha/mq
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/web.yaml
+++ b/infra/k8s/alpha/apps/web.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the Web manifests (Deployment, Service, ConfigMap)
-    path: k8s/alpha/web
+    path: infra/k8s/alpha/web
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/apps/workers.yaml
+++ b/infra/k8s/alpha/apps/workers.yaml
@@ -15,7 +15,7 @@ spec:
     targetRevision: staging
 
     # Path to the Workers manifests (Deployments, ConfigMap, Kustomization)
-    path: k8s/alpha/workers
+    path: infra/k8s/alpha/workers
 
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/alpha/common/kustomization.yaml
+++ b/infra/k8s/alpha/common/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
-  - https://github.com/podverse/podverse//infra/k8d/base/common?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/common?ref=staging
 
 patches:
   - path: ingress-hosts-patch.yaml

--- a/infra/k8s/alpha/cron/kustomization.yaml
+++ b/infra/k8s/alpha/cron/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/cron?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/cron?ref=staging
 namespace: podverse-alpha
 
 images:

--- a/infra/k8s/alpha/db/kustomization.yaml
+++ b/infra/k8s/alpha/db/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/db?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/db?ref=staging
 
 # 2. Namespace
 namespace: podverse-alpha

--- a/infra/k8s/alpha/keyvaldb/kustomization.yaml
+++ b/infra/k8s/alpha/keyvaldb/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/keyvaldb?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/keyvaldb?ref=staging
   # Note: We will uncomment the secret line below once you run the generation script
   # - k8s/secrets/podverse-keyvaldb-secret.enc.yaml
 

--- a/infra/k8s/alpha/management-web/kustomization.yaml
+++ b/infra/k8s/alpha/management-web/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/management-web?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/management-web?ref=staging
 
 namespace: podverse-alpha
 

--- a/infra/k8s/alpha/mq/kustomization.yaml
+++ b/infra/k8s/alpha/mq/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/mq?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/mq?ref=staging
 
 namespace: podverse-alpha
 

--- a/infra/k8s/alpha/web/kustomization.yaml
+++ b/infra/k8s/alpha/web/kustomization.yaml
@@ -6,7 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/podverse/podverse//infra/k8d/base/web?ref=staging
+  - https://github.com/podverse/podverse//infra/k8s/base/web?ref=staging
 
 namespace: podverse-alpha
 


### PR DESCRIPTION
- Introduced a new guide for deploying Podverse to a remote Kubernetes cluster using Argo CD and a separate GitOps repository, ensuring domain-agnostic documentation for open source use.
- Updated paths in various Kubernetes manifests and Kustomization files to reflect the new directory structure under `infra/k8s/`, enhancing clarity and organization.
- Modified existing documentation to reference the new GitOps guide, improving accessibility for users.