### PR TITLE
feat: add Prometheus extension support and environment variable valid…

### DIFF
--- a/.cursor/rules/extensions-env.mdc
+++ b/.cursor/rules/extensions-env.mdc
@@ -1,0 +1,29 @@
+---
+description: Extension env vars live in the last file section and map to config.extensions.*.
+globs: apps/api/.env.example,apps/management-api/.env.example,infra/k8s/**/source/*.env,apps/api/src/config/index.ts,apps/management-api/src/config/index.ts,apps/**/src/lib/extensions/**
+alwaysApply: false
+---
+
+# Extensions environment variables
+
+Use the **extensions-env** skill (`.cursor/skills/extensions-env/SKILL.md`) for full detail.
+
+## Do
+
+- Put extension-related env vars in the **last** section: `Extensions (forward-looking)`.
+- Map under nested `config.extensions.<service>.<property>` (e.g. `config.extensions.prometheus.enabled`).
+- **All extension env keys must use the `EXT_` prefix** (e.g. `EXT_PROMETHEUS_ENABLED`, not
+  `PROMETHEUS_ENABLED`).
+- Name the service `prometheus` (not `prometheusMetrics`); HTTP resource `metrics` at
+  `/extensions/prometheus/metrics`.
+- Validate optional extension vars under startup category **`Extensions`**, at the **end** of
+  `validateAllEnvironmentVariables` (see **startup-validation-env-order** skill).
+- Register extension HTTP routes via **`registerExtensionRoutes`** (after feature routers), one
+  folder per service under `lib/extensions/<serviceName>/` — not in `registerHealthRoutes`.
+- Prefer paths `{version}/extensions/{service-kebab}/{resource}` (e.g.
+  `/api/v2/extensions/prometheus/metrics`), not top-level `/metrics`.
+
+## Don't
+
+- Use `config.observability.*` or other top-level groups for extension toggles.
+- Place extension vars above other sections (Extensions must be last).

--- a/.cursor/rules/startup-validation-env-order.mdc
+++ b/.cursor/rules/startup-validation-env-order.mdc
@@ -1,0 +1,22 @@
+---
+description: Align startup validation.ts push order with apps/*/.env.example when practical.
+globs: apps/**/lib/startup/validation.ts,apps/workers/src/lib/startup/validation.ts
+alwaysApply: false
+---
+
+# Startup validation order vs env files
+
+Use the **startup-validation-env-order** skill
+(`.cursor/skills/startup-validation-env-order/SKILL.md`) for full detail.
+
+## Do
+
+- Add new `results.push(...)` entries in the same **section order** as `apps/<app>/.env.example`.
+- Place vars from the **last** env section (e.g. Extensions) at the **end** of
+  `validateAllEnvironmentVariables`, with a comment referencing that section.
+- Update validation when you add or move keys in `.env.example`.
+
+## Don't
+
+- Insert extension or late-section env validations into an unrelated block (e.g. API
+  Configuration) just because the validation `category` label differs from the env header.

--- a/.cursor/skills/api/SKILL.md
+++ b/.cursor/skills/api/SKILL.md
@@ -190,6 +190,10 @@ router.get(
 
 See `apps/api/src/lib/startup/validation.ts` for environment variable validation patterns.
 
+**Validation order:** Keep `results.push` order in `validation.ts` aligned with
+`apps/api/.env.example` section order when practical (see
+[startup-validation-env-order](../startup-validation-env-order/SKILL.md)).
+
 **Env file alignment:** All `.env` files (including `infra/config/local/*.env`) must match the organization, section comments, and variable order of their authoritative `.env.example`; only values may differ.
 
 **Lighthouse alignment:** When validation changes here, update

--- a/.cursor/skills/extensions-env/SKILL.md
+++ b/.cursor/skills/extensions-env/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: extensions-env
+description: Extension-related environment variables and nested config.extensions.<service> mapping. Use when adding or editing extension toggles, Prometheus env, or the Extensions section in app env files.
+version: 1.6.0
+---
+
+# Extensions environment variables
+
+## When to use
+
+When adding or editing extension-related env vars in Podverse apps (especially
+`apps/api`, `apps/management-api`), K8s `infra/k8s/base/*/source/*.env`, or
+`apps/*/.env.example`.
+
+## Config mapping (TypeScript)
+
+- Extension settings live under **`config.extensions.<serviceName>`**, grouped by
+  integration/service, with **properties nested inside** that object.
+- Do **not** flatten toggles as `config.extensions.prometheusEnabled` or use
+  `config.observability.*` / other top-level namespaces.
+- Do **not** name the service `prometheusMetrics` — the service is **`prometheus`**; the HTTP
+  resource is **`metrics`**.
+- Example (prometheus extension):
+
+  ```typescript
+  extensions: {
+    prometheus: {
+      enabled: process.env.EXT_PROMETHEUS_ENABLED === 'true',
+    },
+  };
+  ```
+
+  Usage: `config.extensions.prometheus.enabled`.
+
+- Future extensions follow the same shape, e.g.
+  `config.extensions.cloudflareWebAnalytics.token` (when wired).
+- Startup validation category for extension env vars: **`Extensions`**.
+
+## Env file layout (required)
+
+1. **Last section** — The **Extensions** block must be the **final section** in every
+   env template/source file that defines extension vars (nothing after it).
+2. **Section header** — Use this header (exact wording for `.env.example`):
+
+   ```text
+   #####
+   ##### Extensions (forward-looking)
+   #####
+   ```
+
+   For K8s `source/*.env` (no `#####` style), use:
+
+   ```text
+   # Extensions (forward-looking)
+   ```
+
+3. **Comments** — Note that vars in this section are extension-intended even when the
+   current implementation is still baked into core (e.g. temporary `prom-client` path).
+
+## Naming
+
+### Env keys (required `EXT_` prefix)
+
+**All extension-specific environment variables must use the `EXT_` prefix.**
+
+- Pattern: `EXT_<SERVICE>_<PROPERTY>` in `SCREAMING_SNAKE_CASE`.
+- **Service** segment aligns with `config.extensions.<service>` (e.g. `PROMETHEUS` for
+  `config.extensions.prometheus`).
+- **Property** segment describes the setting (`ENABLED`, `TOKEN`, etc.).
+- Current prometheus toggle: **`EXT_PROMETHEUS_ENABLED`** (`"true"` / blank / `"false"`).
+- Do **not** add extension toggles without `EXT_` (e.g. not `PROMETHEUS_ENABLED`,
+  `PROMETHEUS_METRICS_ENABLED`).
+- When the extensions framework lands, additional keys may follow
+  `EXT_<ID>_...` (still under the **last** Extensions section).
+
+### Config keys (`config.extensions`)
+
+- **Service segment:** short camelCase integration id matching the URL segment when possible
+  (e.g. `prometheus`, `cloudflareWebAnalytics`).
+- **Properties:** boolean toggles and other fields **inside** the service object
+  (`enabled`, `token`, etc.), not suffixes on the service name.
+- Map each `EXT_*` env var in `config/index.ts` under the matching `extensions.<service>` object.
+
+## Values
+
+Follow [env-file-formatting](../env-file-formatting/SKILL.md):
+
+- Non-empty: double quotes in `.env.example` (e.g. `EXT_PROMETHEUS_ENABLED="false"`).
+- K8s source: unquoted `false` / `true` per existing `source/*.env` style.
+
+## HTTP routes (per service)
+
+Extension HTTP endpoints are **not** registered in `registerHealthRoutes`. Use the extension
+router pattern:
+
+- `apps/<app>/src/lib/extensions/registerExtensionRoutes.ts` — orchestrator; call after feature
+  routers in `app.ts` / `startApp`, before the error handler.
+- `apps/<app>/src/lib/extensions/<service>/register<Service>Routes.ts` — routes for one
+  extension (e.g. `prometheus/registerPrometheusRoutes.ts` registers the **metrics** resource).
+- `apps/<app>/src/lib/extensions/<service>/` — exporter/runtime for that service only (e.g.
+  `prometheus/prometheusExporter.ts` with `createPrometheusExporter`).
+
+Register extension middleware at app bootstrap when `config.extensions.<service>.enabled`; pass
+runtime into `registerExtensionRoutes(app, baseUrl, config.extensions, { prometheus: exporter })`.
+
+### URL path convention (preferred)
+
+Extension HTTP routes live under the versioned API base, **not** at top-level `/metrics` or mixed
+into health routes:
+
+```text
+{API_PREFIX}{API_VERSION}/extensions/{service}/{resource}
+```
+
+Examples (default prefix/version `/api` + `/v2`):
+
+| `config.extensions` key | Env toggle (example)     | URL path (suffix after version)  | Resource  |
+| ----------------------- | ------------------------ | -------------------------------- | --------- |
+| `prometheus`            | `EXT_PROMETHEUS_ENABLED` | `/extensions/prometheus/metrics` | `metrics` |
+
+- **`service`:** URL segment matches `config.extensions` key (`prometheus` → `prometheus`).
+- **`resource`:** capability endpoint (`metrics`, `webhooks`, etc.).
+- **Prometheus:** exposition format and scrape behavior are unchanged; operators set
+  `metrics_path` to `/api/v2/extensions/prometheus/metrics`. See
+  [PROMETHEUS-METRICS-ENDPOINTS.md](../../docs/operations/PROMETHEUS-METRICS-ENDPOINTS.md).
+
+Define path constants in `lib/extensions/<service>/` (e.g. `prometheus/prometheusPaths.ts`) and use
+them in route registration and tests.
+
+## Files to keep in sync
+
+When adding a new extension env var:
+
+- `apps/<app>/.env.example` — Extensions section at bottom; key must start with `EXT_`
+- `apps/<app>/src/config/index.ts` — nested under `extensions.<serviceName> { ... }`
+- `apps/<app>/src/lib/startup/validation.ts` — `validateOptional(..., 'Extensions', ...)` at the
+  **end** of `validateAllEnvironmentVariables` (aligned with Extensions being the last env
+  section; see [startup-validation-env-order](../startup-validation-env-order/SKILL.md))
+- `apps/<app>/src/lib/extensions/` — per-service route registration (see above)
+- `infra/k8s/base/<app>/source/*.env` — Extensions block at bottom (if the app has K8s env)
+
+## References
+
+- [docs/operations/PROMETHEUS-METRICS-ENDPOINTS.md](../../docs/operations/PROMETHEUS-METRICS-ENDPOINTS.md)
+- [docs/proposals/EXTENSIONS.md](../../docs/proposals/EXTENSIONS.md) (when present on branch)
+- [env-file-formatting](../env-file-formatting/SKILL.md)

--- a/.cursor/skills/startup-validation-env-order/SKILL.md
+++ b/.cursor/skills/startup-validation-env-order/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: startup-validation-env-order
+description: Keep apps/*/lib/startup/validation.ts push order aligned with apps/*/.env.example section order when practical. Use when adding env vars, startup validation entries, or editing validation.ts.
+version: 1.0.0
+---
+
+# Startup validation order vs env files
+
+## When to use
+
+When adding or reordering entries in `apps/<app>/src/lib/startup/validation.ts` (or workers
+equivalent), especially after adding vars to `apps/<app>/.env.example`.
+
+## Rule
+
+**Keep validation `results.push(...)` order aligned with the authoritative env template**
+(`apps/<app>/.env.example`) **when practical:**
+
+1. **Section order** — Group validation blocks in the same sequence as env file sections
+   (e.g. General → API Configuration → Auth → Database → … → Extensions last).
+2. **Within a section** — Push validations for vars in the same order they appear under that
+   section header in `.env.example`.
+3. **Last section = last block** — Vars in the final env section (e.g. **Extensions
+   (forward-looking)**) belong at the **end** of `validateAllEnvironmentVariables`, not
+   mixed into an earlier category block (e.g. do not put `EXT_PROMETHEUS_ENABLED` under
+   API Configuration in validation when it is last in `.env.example`).
+4. **Comments** — Optional short comment tying a validation block to the env section name
+   helps future edits stay aligned.
+
+## Exceptions (OK to diverge)
+
+- **Early validation** — Vars that must be read before others (e.g. `ACCOUNT_SIGNUP_MODE`
+  before conditional mailer checks) may be validated earlier than their env section.
+- **Grouped helpers** — Custom validators (e.g. MetaBoost pair, object-storage bundle) may
+  stay together even if env keys are scattered; keep the _block_ near the related env
+  section when possible.
+- **Display order** — Startup output is grouped by validation `category`, not file order;
+  alignment is for **maintainer ergonomics** when editing both files side by side.
+
+## Files to keep in sync
+
+When adding an env var:
+
+- `apps/<app>/.env.example` — authoritative section + key order
+- `apps/<app>/src/lib/startup/validation.ts` — matching push order (same app)
+- Extension vars: also follow [extensions-env](../extensions-env/SKILL.md) (Extensions
+  section last in env files and validation).
+
+## References
+
+- [extensions-env](../extensions-env/SKILL.md) — Extensions section and validation category
+- [env-file-formatting](../env-file-formatting/SKILL.md) — env value formatting
+- [api](../api/SKILL.md) — API startup validation patterns

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -217,3 +217,10 @@ WEBPUSH_VAPID_PUBLIC_KEY=
 # Local/dev: set here to match workers. Kubernetes: same Secret as workers — `podverse-workers-webpush-opaque`
 WEBPUSH_VAPID_PRIVATE_KEY=
 WEBPUSH_VAPID_SUBJECT=
+
+#####
+##### Extensions (forward-looking)
+#####
+# Extension-intended toggle for the prometheus extension (GET .../extensions/prometheus/metrics).
+# Will map cleanly to extension host wiring in a future migration.
+EXT_PROMETHEUS_ENABLED="false"

--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -330,4 +330,3 @@ paths:
                     example: "Account deleted successfully"
         "401":
           description: Unauthorized or user not logged in.
-

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,6 +50,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "uuid": "^14.0.0"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,8 @@ import express from 'express';
 
 import { CategoryService } from '@podverse/orm';
 
+import { registerExtensionRoutes } from './lib/extensions/registerExtensionRoutes.js';
+import { createPrometheusExporter } from './lib/extensions/prometheus/prometheusExporter.js';
 import { registerHealthRoutes } from './lib/health/registerHealthRoutes.js';
 
 // Route imports are deferred until after ORM initialization (see startApp).
@@ -46,6 +48,15 @@ app.use(cookieParser());
 app.use(initializePassport());
 
 const baseUrl = `${config.api.prefix}${config.api.version}`;
+// TODO(extensions-migration): Replace this in-process exporter bootstrap with the
+// API extension registry/bootstrap flow once extension-based metrics are enabled.
+const prometheusExporter = config.extensions.prometheus.enabled
+  ? createPrometheusExporter('podverse_api')
+  : undefined;
+
+if (prometheusExporter) {
+  app.use(prometheusExporter.httpMiddleware);
+}
 
 export const startApp = async () => {
   try {
@@ -129,6 +140,11 @@ export const startApp = async () => {
     app.use(publisherFeedRouter);
     app.use(queueRouter);
     app.use(statsRouter);
+
+    // --- Extension routes (after feature routers; e.g. prometheus /metrics)
+    registerExtensionRoutes(app, baseUrl, config.extensions, {
+      prometheus: prometheusExporter,
+    });
 
     // --- Error handler
     app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -29,6 +29,11 @@ type Config = {
     level: string;
     dir: string;
   };
+  extensions: {
+    prometheus: {
+      enabled: boolean;
+    };
+  };
   auth: {
     jwtSecret: string;
     /** From AUTH_JWT_EXPIRATION. */
@@ -120,6 +125,11 @@ export const config: Config = {
   log: {
     level: process.env.LOG_LEVEL!,
     dir: process.env.LOG_DIR ?? '',
+  },
+  extensions: {
+    prometheus: {
+      enabled: process.env.EXT_PROMETHEUS_ENABLED === 'true',
+    },
   },
   auth: (() => {
     const jwtExpiration = readOptionalPositiveExpirationEnv(

--- a/apps/api/src/lib/extensions/prometheus/prometheusExporter.ts
+++ b/apps/api/src/lib/extensions/prometheus/prometheusExporter.ts
@@ -1,0 +1,80 @@
+import type { NextFunction, Request, Response } from 'express';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+import type { PrometheusScrapeEndpoint } from '../types.js';
+
+// TODO(extensions-migration): Move this baked-in prometheus adapter into an extensions package
+// and load it via the extension host wiring.
+export type PrometheusExporter = {
+  httpMiddleware: (req: Request, res: Response, next: NextFunction) => void;
+  endpoint: PrometheusScrapeEndpoint;
+};
+
+const HTTP_DURATION_BUCKETS_SECONDS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.3, 1, 2.5, 5, 10];
+
+const getRouteLabel = (req: Request): string => {
+  const routePath = req.route?.path;
+  if (typeof routePath === 'string') {
+    return `${req.baseUrl}${routePath}`;
+  }
+
+  if (Array.isArray(routePath)) {
+    return `${req.baseUrl}${routePath.join('|')}`;
+  }
+
+  return 'unmatched';
+};
+
+export const createPrometheusExporter = (servicePrefix: string): PrometheusExporter => {
+  const registry = new Registry();
+  collectDefaultMetrics({
+    register: registry,
+    prefix: `${servicePrefix}_`,
+  });
+
+  const httpRequestsTotal = new Counter({
+    name: `${servicePrefix}_http_requests_total`,
+    help: 'Total number of completed HTTP requests',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    registers: [registry],
+  });
+
+  const httpRequestDurationSeconds = new Histogram({
+    name: `${servicePrefix}_http_request_duration_seconds`,
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    buckets: HTTP_DURATION_BUCKETS_SECONDS,
+    registers: [registry],
+  });
+
+  const httpRequestsInFlight = new Gauge({
+    name: `${servicePrefix}_http_requests_in_flight`,
+    help: 'Number of in-flight HTTP requests',
+    labelNames: ['method'] as const,
+    registers: [registry],
+  });
+
+  const httpMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+    const method = req.method;
+    httpRequestsInFlight.inc({ method });
+    const end = httpRequestDurationSeconds.startTimer();
+
+    res.on('finish', () => {
+      const statusCode = res.statusCode.toString();
+      const finishedRoute = getRouteLabel(req);
+      httpRequestsTotal.inc({ method, route: finishedRoute, status_code: statusCode });
+      end({ method, route: finishedRoute, status_code: statusCode });
+      httpRequestsInFlight.dec({ method });
+    });
+
+    next();
+  };
+
+  return {
+    httpMiddleware,
+    endpoint: {
+      contentType: registry.contentType,
+      getMetrics: async (): Promise<string> => registry.metrics(),
+    },
+  };
+};

--- a/apps/api/src/lib/extensions/prometheus/prometheusPaths.ts
+++ b/apps/api/src/lib/extensions/prometheus/prometheusPaths.ts
@@ -1,0 +1,5 @@
+/** Metrics resource path under the prometheus extension (after versioned API base). */
+export const PROMETHEUS_METRICS_PATH = '/extensions/prometheus/metrics';
+
+export const prometheusMetricsRoutePath = (apiVersionBasePath: string): string =>
+  `${apiVersionBasePath}${PROMETHEUS_METRICS_PATH}`;

--- a/apps/api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
+++ b/apps/api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
@@ -1,7 +1,6 @@
 import type { IRouter, Request, Response } from 'express';
 
 import type { PrometheusScrapeEndpoint } from '../types.js';
-
 import { prometheusMetricsRoutePath } from './prometheusPaths.js';
 
 /**

--- a/apps/api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
+++ b/apps/api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
@@ -1,0 +1,22 @@
+import type { IRouter, Request, Response } from 'express';
+
+import type { PrometheusScrapeEndpoint } from '../types.js';
+
+import { prometheusMetricsRoutePath } from './prometheusPaths.js';
+
+/**
+ * Registers prometheus extension routes (e.g. GET /api/v2/extensions/prometheus/metrics).
+ */
+export function registerPrometheusRoutes(
+  router: IRouter,
+  apiVersionBasePath: string,
+  metricsEndpoint: PrometheusScrapeEndpoint
+): void {
+  router.get(
+    prometheusMetricsRoutePath(apiVersionBasePath),
+    async (_req: Request, res: Response) => {
+      res.setHeader('Content-Type', metricsEndpoint.contentType);
+      res.status(200).send(await metricsEndpoint.getMetrics());
+    }
+  );
+}

--- a/apps/api/src/lib/extensions/registerExtensionRoutes.prometheus.test.ts
+++ b/apps/api/src/lib/extensions/registerExtensionRoutes.prometheus.test.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { prometheusMetricsRoutePath } from './prometheus/prometheusPaths.js';
+import { registerExtensionRoutes } from './registerExtensionRoutes.js';
+
+const apiBase = '/api/v2';
+const metricsPath = prometheusMetricsRoutePath(apiBase);
+
+describe('registerExtensionRoutes prometheus', () => {
+  it('registers GET /extensions/prometheus/metrics when prometheus is enabled with runtime exporter', async () => {
+    const app = express();
+    registerExtensionRoutes(
+      app,
+      apiBase,
+      { prometheus: { enabled: true } },
+      {
+        prometheus: {
+          httpMiddleware: (_req, _res, next) => {
+            next();
+          },
+          endpoint: {
+            contentType: 'text/plain; version=0.0.4',
+            getMetrics: async () =>
+              '# HELP test_metric Test metric\n# TYPE test_metric counter\ntest_metric 1\n',
+          },
+        },
+      }
+    );
+
+    const res = await request(app).get(metricsPath).expect(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.headers['content-type']).toContain('version=0.0.4');
+    expect(res.text).toContain('test_metric 1');
+  });
+
+  it('does not register GET /extensions/prometheus/metrics when prometheus is disabled', async () => {
+    const app = express();
+    registerExtensionRoutes(app, apiBase, { prometheus: { enabled: false } });
+
+    await request(app).get(metricsPath).expect(404);
+  });
+
+  it('does not register GET /extensions/prometheus/metrics when enabled but runtime exporter is omitted', async () => {
+    const app = express();
+    registerExtensionRoutes(app, apiBase, { prometheus: { enabled: true } });
+
+    await request(app).get(metricsPath).expect(404);
+  });
+});

--- a/apps/api/src/lib/extensions/registerExtensionRoutes.ts
+++ b/apps/api/src/lib/extensions/registerExtensionRoutes.ts
@@ -1,0 +1,29 @@
+import type { IRouter } from 'express';
+
+import type { PrometheusExporter } from './prometheus/prometheusExporter.js';
+import { registerPrometheusRoutes } from './prometheus/registerPrometheusRoutes.js';
+
+/** Subset of `config.extensions` used when registering extension routes. */
+export type ExtensionRoutesConfig = {
+  prometheus: {
+    enabled: boolean;
+  };
+};
+
+export type RegisterExtensionRoutesRuntime = {
+  prometheus?: PrometheusExporter;
+};
+
+/**
+ * Registers versioned routes for enabled extension services (below feature routers in app bootstrap).
+ */
+export function registerExtensionRoutes(
+  router: IRouter,
+  apiVersionBasePath: string,
+  extensions: ExtensionRoutesConfig,
+  runtime: RegisterExtensionRoutesRuntime = {}
+): void {
+  if (extensions.prometheus.enabled && runtime.prometheus) {
+    registerPrometheusRoutes(router, apiVersionBasePath, runtime.prometheus.endpoint);
+  }
+}

--- a/apps/api/src/lib/extensions/types.ts
+++ b/apps/api/src/lib/extensions/types.ts
@@ -1,0 +1,5 @@
+/** Scrape payload for the prometheus extension `GET .../extensions/prometheus/metrics` route. */
+export type PrometheusScrapeEndpoint = {
+  contentType: string;
+  getMetrics: () => Promise<string>;
+};

--- a/apps/api/src/lib/startup/validation.ts
+++ b/apps/api/src/lib/startup/validation.ts
@@ -309,6 +309,15 @@ const validateAllEnvironmentVariables = (): ValidationSummary => {
     validateOptional('LOG_DIR', 'General', 'Optional - empty for localhost, set for file logging')
   );
 
+  // Extensions (forward-looking) — last in apps/api/.env.example
+  results.push(
+    validateOptional(
+      'EXT_PROMETHEUS_ENABLED',
+      'Extensions',
+      'Blank/false: disabled; true: expose GET .../extensions/prometheus/metrics'
+    )
+  );
+
   // Calculate summary
   const total = results.length;
   const passed = results.filter((r) => r.isValid && r.isSet).length;

--- a/apps/api/src/test/health-ready.test.ts
+++ b/apps/api/src/test/health-ready.test.ts
@@ -52,4 +52,8 @@ describe('API health routes', () => {
     const res = await request(app).get(`${apiBase}/health/ready`).expect(200);
     expect(res.body).toMatchObject({ status: 'ok', message: 'Ready' });
   });
+
+  it(`GET ${apiBase}/extensions/prometheus/metrics returns 404 when EXT_PROMETHEUS_ENABLED is not true`, async () => {
+    await request(app).get(`${apiBase}/extensions/prometheus/metrics`).expect(404);
+  });
 });

--- a/apps/management-api/.env.example
+++ b/apps/management-api/.env.example
@@ -121,3 +121,10 @@ BUCKET_CDN_BASE_URL=
 BUCKET_ENDPOINT=
 # BUCKET_FORCE_PATH_STYLE: true | false | unset (unset = provider default).
 BUCKET_FORCE_PATH_STYLE=
+
+#####
+##### Extensions (forward-looking)
+#####
+# Extension-intended toggle for the prometheus extension (GET .../extensions/prometheus/metrics).
+# Will map cleanly to extension host wiring in a future migration.
+EXT_PROMETHEUS_ENABLED="false"

--- a/apps/management-api/openapi.yml
+++ b/apps/management-api/openapi.yml
@@ -396,4 +396,3 @@ paths:
       responses:
         "200":
           description: Success.
-

--- a/apps/management-api/package.json
+++ b/apps/management-api/package.json
@@ -39,6 +39,7 @@
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "pg": "^8.20.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.26",
     "typeorm-naming-strategies": "^4.1.0"

--- a/apps/management-api/src/app.ts
+++ b/apps/management-api/src/app.ts
@@ -4,6 +4,8 @@ import 'reflect-metadata';
 
 import { config } from '@mgmt-api/config/index.js';
 import { initializePassport } from '@mgmt-api/lib/auth/index.js';
+import { registerExtensionRoutes } from '@mgmt-api/lib/extensions/registerExtensionRoutes.js';
+import { createPrometheusExporter } from '@mgmt-api/lib/extensions/prometheus/prometheusExporter.js';
 import { registerHealthRoutes } from '@mgmt-api/lib/health/registerHealthRoutes.js';
 import { adminsRouter } from '@mgmt-api/routes/admins.js';
 import { authRouter } from '@mgmt-api/routes/auth.js';
@@ -50,6 +52,15 @@ app.use(cookieParser());
 app.use(initializePassport());
 
 const baseUrl = `${config.api.prefix}${config.api.version}`;
+// TODO(extensions-migration): Replace this in-process exporter bootstrap with the
+// management-api extension registry/bootstrap flow once extension-based metrics land.
+const prometheusExporter = config.extensions.prometheus.enabled
+  ? createPrometheusExporter('podverse_management_api')
+  : undefined;
+
+if (prometheusExporter) {
+  app.use(prometheusExporter.httpMiddleware);
+}
 
 // --- Unversioned GET /
 // Informal dev ping only (not for K8s probes — use versioned /health).
@@ -78,6 +89,11 @@ app.use(statsRouter);
 app.use(storageRouter);
 app.use(usersRouter);
 app.use(workersRouter);
+
+// --- Extension routes (after feature routers; e.g. prometheus /metrics)
+registerExtensionRoutes(app, baseUrl, config.extensions, {
+  prometheus: prometheusExporter,
+});
 
 // --- Error handler
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {

--- a/apps/management-api/src/config/index.ts
+++ b/apps/management-api/src/config/index.ts
@@ -14,6 +14,11 @@ type Config = {
   log: {
     level: string;
   };
+  extensions: {
+    prometheus: {
+      enabled: boolean;
+    };
+  };
   auth: {
     jwtSecret: string;
     jwtExpiration: number;
@@ -69,6 +74,11 @@ export const config: Config = {
   brandName: process.env.BRAND_NAME!,
   log: {
     level: process.env.LOG_LEVEL!,
+  },
+  extensions: {
+    prometheus: {
+      enabled: process.env.EXT_PROMETHEUS_ENABLED === 'true',
+    },
   },
   auth: (() => {
     const jwtExpiration = readOptionalPositiveExpirationEnv(

--- a/apps/management-api/src/lib/extensions/prometheus/prometheusExporter.ts
+++ b/apps/management-api/src/lib/extensions/prometheus/prometheusExporter.ts
@@ -1,0 +1,80 @@
+import type { NextFunction, Request, Response } from 'express';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+import type { PrometheusScrapeEndpoint } from '../types.js';
+
+// TODO(extensions-migration): Move this baked-in prometheus adapter into an extensions package
+// and load it via the extension host wiring.
+export type PrometheusExporter = {
+  httpMiddleware: (req: Request, res: Response, next: NextFunction) => void;
+  endpoint: PrometheusScrapeEndpoint;
+};
+
+const HTTP_DURATION_BUCKETS_SECONDS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.3, 1, 2.5, 5, 10];
+
+const getRouteLabel = (req: Request): string => {
+  const routePath = req.route?.path;
+  if (typeof routePath === 'string') {
+    return `${req.baseUrl}${routePath}`;
+  }
+
+  if (Array.isArray(routePath)) {
+    return `${req.baseUrl}${routePath.join('|')}`;
+  }
+
+  return 'unmatched';
+};
+
+export const createPrometheusExporter = (servicePrefix: string): PrometheusExporter => {
+  const registry = new Registry();
+  collectDefaultMetrics({
+    register: registry,
+    prefix: `${servicePrefix}_`,
+  });
+
+  const httpRequestsTotal = new Counter({
+    name: `${servicePrefix}_http_requests_total`,
+    help: 'Total number of completed HTTP requests',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    registers: [registry],
+  });
+
+  const httpRequestDurationSeconds = new Histogram({
+    name: `${servicePrefix}_http_request_duration_seconds`,
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    buckets: HTTP_DURATION_BUCKETS_SECONDS,
+    registers: [registry],
+  });
+
+  const httpRequestsInFlight = new Gauge({
+    name: `${servicePrefix}_http_requests_in_flight`,
+    help: 'Number of in-flight HTTP requests',
+    labelNames: ['method'] as const,
+    registers: [registry],
+  });
+
+  const httpMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+    const method = req.method;
+    httpRequestsInFlight.inc({ method });
+    const end = httpRequestDurationSeconds.startTimer();
+
+    res.on('finish', () => {
+      const statusCode = res.statusCode.toString();
+      const finishedRoute = getRouteLabel(req);
+      httpRequestsTotal.inc({ method, route: finishedRoute, status_code: statusCode });
+      end({ method, route: finishedRoute, status_code: statusCode });
+      httpRequestsInFlight.dec({ method });
+    });
+
+    next();
+  };
+
+  return {
+    httpMiddleware,
+    endpoint: {
+      contentType: registry.contentType,
+      getMetrics: async (): Promise<string> => registry.metrics(),
+    },
+  };
+};

--- a/apps/management-api/src/lib/extensions/prometheus/prometheusPaths.ts
+++ b/apps/management-api/src/lib/extensions/prometheus/prometheusPaths.ts
@@ -1,0 +1,5 @@
+/** Metrics resource path under the prometheus extension (after versioned API base). */
+export const PROMETHEUS_METRICS_PATH = '/extensions/prometheus/metrics';
+
+export const prometheusMetricsRoutePath = (apiVersionBasePath: string): string =>
+  `${apiVersionBasePath}${PROMETHEUS_METRICS_PATH}`;

--- a/apps/management-api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
+++ b/apps/management-api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
@@ -1,7 +1,6 @@
 import type { IRouter, Request, Response } from 'express';
 
 import type { PrometheusScrapeEndpoint } from '../types.js';
-
 import { prometheusMetricsRoutePath } from './prometheusPaths.js';
 
 /**

--- a/apps/management-api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
+++ b/apps/management-api/src/lib/extensions/prometheus/registerPrometheusRoutes.ts
@@ -1,0 +1,22 @@
+import type { IRouter, Request, Response } from 'express';
+
+import type { PrometheusScrapeEndpoint } from '../types.js';
+
+import { prometheusMetricsRoutePath } from './prometheusPaths.js';
+
+/**
+ * Registers prometheus extension routes (e.g. GET /api/v2/extensions/prometheus/metrics).
+ */
+export function registerPrometheusRoutes(
+  router: IRouter,
+  apiVersionBasePath: string,
+  metricsEndpoint: PrometheusScrapeEndpoint
+): void {
+  router.get(
+    prometheusMetricsRoutePath(apiVersionBasePath),
+    async (_req: Request, res: Response) => {
+      res.setHeader('Content-Type', metricsEndpoint.contentType);
+      res.status(200).send(await metricsEndpoint.getMetrics());
+    }
+  );
+}

--- a/apps/management-api/src/lib/extensions/registerExtensionRoutes.prometheus.test.ts
+++ b/apps/management-api/src/lib/extensions/registerExtensionRoutes.prometheus.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { prometheusMetricsRoutePath } from './prometheus/prometheusPaths.js';
+import { registerExtensionRoutes } from './registerExtensionRoutes.js';
+
+const apiBase = '/api/v2';
+const metricsPath = prometheusMetricsRoutePath(apiBase);
+
+describe('management-api registerExtensionRoutes prometheus', () => {
+  it('registers GET /extensions/prometheus/metrics when prometheus is enabled with runtime exporter', async () => {
+    const app = express();
+    registerExtensionRoutes(
+      app,
+      apiBase,
+      { prometheus: { enabled: true } },
+      {
+        prometheus: {
+          httpMiddleware: (_req, _res, next) => {
+            next();
+          },
+          endpoint: {
+            contentType: 'text/plain; version=0.0.4',
+            getMetrics: async () =>
+              '# HELP test_metric Test metric\n# TYPE test_metric counter\ntest_metric 1\n',
+          },
+        },
+      }
+    );
+
+    const res = await request(app).get(metricsPath).expect(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.headers['content-type']).toContain('version=0.0.4');
+    expect(res.text).toContain('test_metric 1');
+  });
+
+  it('does not register GET /extensions/prometheus/metrics when prometheus is disabled', async () => {
+    const app = express();
+    registerExtensionRoutes(app, apiBase, { prometheus: { enabled: false } });
+
+    await request(app).get(metricsPath).expect(404);
+  });
+});

--- a/apps/management-api/src/lib/extensions/registerExtensionRoutes.ts
+++ b/apps/management-api/src/lib/extensions/registerExtensionRoutes.ts
@@ -1,0 +1,29 @@
+import type { IRouter } from 'express';
+
+import type { PrometheusExporter } from './prometheus/prometheusExporter.js';
+import { registerPrometheusRoutes } from './prometheus/registerPrometheusRoutes.js';
+
+/** Subset of `config.extensions` used when registering extension routes. */
+export type ExtensionRoutesConfig = {
+  prometheus: {
+    enabled: boolean;
+  };
+};
+
+export type RegisterExtensionRoutesRuntime = {
+  prometheus?: PrometheusExporter;
+};
+
+/**
+ * Registers versioned routes for enabled extension services (below feature routers in app bootstrap).
+ */
+export function registerExtensionRoutes(
+  router: IRouter,
+  apiVersionBasePath: string,
+  extensions: ExtensionRoutesConfig,
+  runtime: RegisterExtensionRoutesRuntime = {}
+): void {
+  if (extensions.prometheus.enabled && runtime.prometheus) {
+    registerPrometheusRoutes(router, apiVersionBasePath, runtime.prometheus.endpoint);
+  }
+}

--- a/apps/management-api/src/lib/extensions/types.ts
+++ b/apps/management-api/src/lib/extensions/types.ts
@@ -1,0 +1,5 @@
+/** Scrape payload for the prometheus extension `GET .../extensions/prometheus/metrics` route. */
+export type PrometheusScrapeEndpoint = {
+  contentType: string;
+  getMetrics: () => Promise<string>;
+};

--- a/apps/management-api/src/lib/startup/validation.ts
+++ b/apps/management-api/src/lib/startup/validation.ts
@@ -134,6 +134,15 @@ const validateAllEnvironmentVariables = (): ValidationSummary => {
   results.push(validateRequired('NODE_ENV', 'General'));
   results.push(validateRequired('LOG_LEVEL', 'General'));
 
+  // Extensions (forward-looking) — last in apps/management-api/.env.example
+  results.push(
+    validateOptional(
+      'EXT_PROMETHEUS_ENABLED',
+      'Extensions',
+      'Blank/false: disabled; true: expose GET .../extensions/prometheus/metrics'
+    )
+  );
+
   // Calculate summary
   const total = results.length;
   const passed = results.filter((r) => r.isValid && r.isSet).length;

--- a/apps/management-api/src/routes/auth.integration.test.ts
+++ b/apps/management-api/src/routes/auth.integration.test.ts
@@ -253,6 +253,13 @@ describe('management-api auth routes', () => {
       expect(res.status).toBe(503);
       expect(res.body).toMatchObject({ status: 'unavailable' });
     });
+
+    it('returns 404 on /extensions/prometheus/metrics when EXT_PROMETHEUS_ENABLED is not true', async () => {
+      const baseUrl = `${config.api.prefix}${config.api.version}`;
+      const res = await request(app).get(`${baseUrl}/extensions/prometheus/metrics`);
+
+      expect(res.status).toBe(404);
+    });
   });
 
   describe('POST /auth/mobile/*', () => {

--- a/docs/operations/PROMETHEUS-METRICS-ENDPOINTS.md
+++ b/docs/operations/PROMETHEUS-METRICS-ENDPOINTS.md
@@ -1,0 +1,79 @@
+# Prometheus Metrics Endpoints
+
+Podverse exposes Prometheus scrape endpoints but does not bundle, deploy, or manage Prometheus.
+Deployers decide how Prometheus (and optional Grafana/Alertmanager) fits their architecture.
+Current implementation note: this endpoint is currently powered by a baked-in `prom-client`
+adapter under `lib/extensions/prometheus/` and registered via `registerExtensionRoutes`
+(after feature routers). It is expected to migrate to extension-host wiring in a future phase.
+
+## Scope
+
+- Podverse API (`apps/api`) can expose `GET /api/v2/extensions/prometheus/metrics`.
+- Podverse Management API (`apps/management-api`) can expose
+  `GET /api/v2/extensions/prometheus/metrics`.
+- Endpoints are disabled by default.
+
+Extension routes use the pattern `{API_PREFIX}{API_VERSION}/extensions/{service}/{resource}`.
+The **prometheus** extension exposes the **metrics** resource at `/extensions/prometheus/metrics`.
+Prometheus only requires a GET that returns exposition format; configure scrape targets with
+`metrics_path` (or equivalent).
+
+## Enable Or Disable
+
+Set this environment variable per service (last section in app env files; maps to
+`config.extensions.prometheus.enabled`):
+
+```bash
+EXT_PROMETHEUS_ENABLED="true"
+```
+
+Behavior:
+
+- `true`: service registers `GET /api/v2/extensions/prometheus/metrics`.
+- unset or `false`: that route is not registered (returns 404).
+
+## Prometheus scrape configuration
+
+Example static scrape (adjust host/port per environment):
+
+```yaml
+scrape_configs:
+  - job_name: podverse_api
+    static_configs:
+      - targets: ['api.example.internal:3000']
+    metrics_path: /api/v2/extensions/prometheus/metrics
+```
+
+## Prometheus Model
+
+- Pull model only: Prometheus scrapes Podverse endpoints.
+- No custom POST ingestion endpoint in Podverse.
+- No metrics persisted in Postgres.
+
+## Data Exposed
+
+When enabled, each API exports:
+
+- process/runtime defaults from `prom-client`
+- HTTP request totals (`*_http_requests_total`)
+- HTTP request duration histogram (`*_http_request_duration_seconds`)
+- in-flight request gauge (`*_http_requests_in_flight`)
+
+Metric prefixes:
+
+- `podverse_api_*` for API
+- `podverse_management_api_*` for management-api
+
+## Label Guardrails
+
+To keep cardinality safe, HTTP metrics use a fixed label allowlist:
+
+- `method`
+- `route`
+- `status_code`
+
+Do not add user IDs, feed URLs, IP addresses, or other unbounded labels.
+
+## Operator Note
+
+Keep metrics endpoints private to trusted networks where possible (cluster-local or private ingress).

--- a/infra/k8s/base/api/source/api.env
+++ b/infra/k8s/base/api/source/api.env
@@ -84,3 +84,7 @@ WEBPUSH_ENABLED=
 WEBPUSH_VAPID_PUBLIC_KEY=
 # WEBPUSH_VAPID_PRIVATE_KEY: in `podverse-workers-webpush-opaque` only (not in this ConfigMap)
 WEBPUSH_VAPID_SUBJECT=mailto:contact@example.com
+
+# Extensions (forward-looking)
+# EXT_PROMETHEUS_ENABLED: extension-intended toggle for prometheus extension (/extensions/prometheus/metrics)
+EXT_PROMETHEUS_ENABLED=false

--- a/infra/k8s/base/management-api/source/management-api.env
+++ b/infra/k8s/base/management-api/source/management-api.env
@@ -35,3 +35,7 @@ MEMBERSHIP_PREMIUM_COST_MONTHLY=3
 MEMBERSHIP_PREMIUM_COST_ANNUALLY=30
 MEMBERSHIP_PREMIUM_TRACK_STATS=true
 MEMBERSHIP_PREMIUM_ALLOW_NOTIFICATIONS=true
+
+# Extensions (forward-looking)
+# EXT_PROMETHEUS_ENABLED: extension-intended toggle for prometheus extension (/extensions/prometheus/metrics)
+EXT_PROMETHEUS_ENABLED=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "uuid": "^14.0.0"
       },
@@ -115,6 +116,7 @@
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
         "pg": "^8.20.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.26",
         "typeorm-naming-strategies": "^4.1.0"
@@ -3313,7 +3315,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -7438,6 +7439,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "4.12.3",
@@ -11942,268 +11949,6 @@
         }
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MPL-2.0",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -13655,16 +13400,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/node-addon-api": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
@@ -14812,6 +14547,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/property-information": {
@@ -16694,6 +16442,15 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/teeny-request": {


### PR DESCRIPTION
…ation

- Introduced the Prometheus extension to expose metrics via the `/extensions/prometheus/metrics` endpoint.
- Added environment variable `EXT_PROMETHEUS_ENABLED` to control the activation of the Prometheus extension.
- Updated configuration to include Prometheus settings under `config.extensions`.
- Implemented route registration for the Prometheus metrics endpoint in both API and management API.
- Enhanced environment variable validation to ensure proper setup for the Prometheus extension.
- Created tests to verify the correct registration and response of the Prometheus metrics endpoint.