### PR TITLE
feat(docs): update env file formatting rules for Node/Docker and K8s

### DIFF
--- a/.cursor/rules/env-file-formatting.mdc
+++ b/.cursor/rules/env-file-formatting.mdc
@@ -1,5 +1,5 @@
 ---
-description: Formatting rules for .env and .env.example files
+description: Formatting rules for Node/Docker env files (not K8s source/*.env)
 globs:
   - "**/.env"
   - "**/.env.*"
@@ -9,9 +9,17 @@ alwaysApply: false
 
 # Environment File Formatting
 
-This rule applies to **all** env var files in the repo: app `.env.example` files, `infra/config/env-templates/*.env.example`, and `dev/env-overrides/local/*.env.example`. Scripts that write env content (e.g. `scripts/local-env/setup.sh`) must follow the same pattern.
+## Scope
 
-## Formatting Rules
+**Double-quote rules below apply to Node and Docker env files only:** app `.env.example` files,
+`infra/config/env-templates/*.env.example`, `infra/config/local/*.env`, and
+`dev/env-overrides/local/*.env.example`. Scripts that write env content (e.g.
+`scripts/local-env/setup.sh`) must follow the same pattern.
+
+**Exception — K8s ConfigMap sources:** `infra/k8s/**/source/*.env` uses **unquoted** values
+(including numbers). See `.cursor/skills/env-file-formatting/SKILL.md` § K8s ConfigMap `source/*.env`.
+
+## Node / Docker formatting rules
 
 1. **Non-empty values** must be surrounded with double quotation marks
 2. **Empty/unset values** should have no value after the `=` sign (no quotes, no empty string)
@@ -20,6 +28,7 @@ This rule applies to **all** env var files in the repo: app `.env.example` files
 ```
 DATABASE_HOST="localhost"
 API_KEY="abc123"
+API_PORT="3000"
 EMPTY_VALUE=
 URL_WITH_SPECIAL_CHARS="http://example.com?foo=bar&baz=qux"
 ```
@@ -28,19 +37,24 @@ URL_WITH_SPECIAL_CHARS="http://example.com?foo=bar&baz=qux"
 ```
 DATABASE_HOST=localhost
 API_KEY=abc123
+API_PORT=3000
 EMPTY_VALUE=""
 URL_WITH_SPECIAL_CHARS=http://example.com?foo=bar&baz=qux
 ```
 
-## K8s `source/*.env` templates
+## K8s `source/*.env` (exception)
 
-Files under `infra/k8s/**/source/*.env` (and GitOps copies) follow the value rules above. For comments that name env vars, use **one variable per line** in each `#` comment. Do not combine multiple variable names in a single comment line (e.g. `VAR1, VAR2: …`). If the same note applies to two keys, use two comment lines and duplicate the text.
+Files under `infra/k8s/**/source/*.env` (and GitOps copies) use **unquoted** values:
+`DB_PORT=5432`, `NODE_ENV=production`, `LOG_DIR=`. For comments that name env vars, use **one
+variable per line** in each `#` comment. Do not combine multiple variable names in a single comment
+line (e.g. `VAR1, VAR2: …`). If the same note applies to two keys, use two comment lines and
+duplicate the text.
 
 ## Order: non-`NEXT_PUBLIC_*` before `NEXT_PUBLIC_*`
 
 When a file mixes server-side keys with `NEXT_PUBLIC_*`, list **all non-`NEXT_PUBLIC_*` assignments first**, blank line, then all `NEXT_PUBLIC_*`. See `.cursor/skills/env-file-formatting/SKILL.md`.
 
-## Rationale
+## Rationale (Node / Docker)
 
 - Quotation marks ensure consistent parsing across different tools (dotenv, dotenvx, shell scripts)
 - Quotation marks prevent issues with special characters (spaces, `&`, `=`, `#`, etc.)

--- a/.cursor/rules/infra-k8s.mdc
+++ b/.cursor/rules/infra-k8s.mdc
@@ -25,11 +25,22 @@ K8s YAML is formatted with Prettier using **k8s-specific overrides** (see root `
 
 ## ConfigMap Conventions
 
-- **Sync with env-templates:** ConfigMaps in `base/<component>/01-configmap.yaml` mirror structure of `infra/config/env-templates/<component>.env.example`
-- **Section headers:** Use comments like `##### App / General #####`
+- **Env sources:** Prefer `configMapGenerator` + `base/<component>/source/*.env` (and overlay merge
+  fragments). Sync keys with `infra/config/env-templates/<component>.env.example` and app
+  `.env.example`; use **unquoted** values in `source/*.env` (see **env-file-formatting** skill).
+- **Section headers:** Use comments like `##### App / General #####` in env source files.
 - **No secrets:** Mark sensitive vars with `# in secrets` comment; actual secrets go in SOPS-encrypted files. When several consecutive lines have `# in secrets`, align that comment vertically (same column).
-- **String values:** Use double quotes (e.g., `NODE_ENV: "production"`)
-- **Comments:** Reference source (e.g., `# Mapped from config/podverse-api.env.example`)
+- **Comments:** Reference source (e.g., `# Mapped from apps/api/.env.example`).
+
+## Value types in YAML
+
+- **String fields** (OpenAPI `type: string`): double-quoted scalars are fine; Prettier uses
+  `singleQuote: false` for YAML strings.
+- **Integer / float fields** (OpenAPI `type: integer` or `number`): use **unquoted YAML numbers**.
+  Never write `"123"` where the schema expects a numeric type (e.g. `replicas`, `containerPort`,
+  probe `periodSeconds`, `failureThreshold`).
+- **Container `env[].value`:** typed as **string** in the Kubernetes API — `value: "5432"` is valid
+  for env overrides; do not confuse with numeric schema fields above.
 
 ## Base Resource Naming
 

--- a/.cursor/skills/env-file-formatting/SKILL.md
+++ b/.cursor/skills/env-file-formatting/SKILL.md
@@ -1,23 +1,42 @@
 ---
 name: env-file-formatting
-description: Env file value formatting (double quotes for non-empty). Use when adding or editing
-  .env, .env.example, or any *.env template in the repo.
+description: Env file value formatting — double quotes for Node/Docker .env; unquoted values for
+  K8s source/*.env. Use when adding or editing .env, .env.example, or env templates.
 ---
 
 # Env file formatting
 
 ## When to use
 
-When adding or editing `.env`, `.env.example`, or any `*.env` template in the repo (including
-`infra/config/env-templates/*.env.example` and `dev/env-overrides/local/*.env.example`).
+When adding or editing env var files. **Which rules apply depends on the file path** (see below).
 
-## Rules
+## Node / Docker env files
 
-- **Non-empty values**: Use double quotes. Example: `DATABASE_HOST="localhost"`, `NODE_ENV="development"`.
+Applies to app `.env` / `.env.example`, `infra/config/env-templates/*.env.example`,
+`infra/config/local/*.env`, `dev/env-overrides/local/*.env.example`, and Docker Compose env files.
+
+- **Non-empty values**: Use double quotes. Example: `DATABASE_HOST="localhost"`, `API_PORT="3000"`.
 - **Empty/unset values**: No value after `=` (no quotes, no empty string). Example: `API_KEY=`.
 
 Scripts that write env content (e.g. `scripts/local-env/setup.sh`) already emit this format;
 templates and examples should match so that copied or generated files are consistent.
+
+## K8s ConfigMap `source/*.env`
+
+Applies to `infra/k8s/**/source/*.env` (and GitOps overlay copies) consumed by `configMapGenerator`.
+
+- **Values are unquoted** (kustomize env-file semantics — quoted values would embed stray `"` in
+  ConfigMap data).
+- **Numbers are unquoted**: `DB_PORT=5432`, not `DB_PORT="5432"`.
+- **Empty/unset**: `KEY=` (same as Node/Docker).
+- **Comments**: at most **one environment variable name per `#` line**. Do not list several names in
+  one line. If two variables share the same note, repeat the full comment on a second line.
+
+Keep keys aligned with `infra/config/env-templates/*.env.example`; only values and K8s-specific
+hostnames differ.
+
+For **K8s YAML manifest** value types (string vs numeric OpenAPI fields), see **k8s** skill and
+**infra-k8s** rule — not this skill.
 
 ## Variable order when mixing server and `NEXT_PUBLIC_*`
 
@@ -31,12 +50,9 @@ keys:
 
 Files that contain only `NEXT_PUBLIC_*` or only server keys need no extra ordering rule.
 
-## K8s ConfigMap `source/*.env` (infra)
-
-Templates that become ConfigMap data under `infra/k8s/**/source/*.env` (and GitOps copies) follow the same **value** rules as above. For **comments** that document where a value comes from: use **at most one environment variable name per `#` line**. Do not list several variable names in one line (e.g. comma-separated). If two variables share the same note, repeat the full comment on a second line.
-
 ## References
 
 - [.cursor/rules/env-file-formatting.mdc](../../.cursor/rules/env-file-formatting.mdc) — cursor rule (globs and examples)
+- [.cursor/rules/infra-k8s.mdc](../../.cursor/rules/infra-k8s.mdc) — K8s YAML string vs numeric typing
 - [AGENTS.md](../../AGENTS.md) — "In .env files" / Non-empty values / Empty values
 - [scripts/local-env/setup.sh](../../scripts/local-env/setup.sh) — `upsert_var()` writes `VAR="value"` or `VAR=`

--- a/.cursor/skills/k8s/SKILL.md
+++ b/.cursor/skills/k8s/SKILL.md
@@ -128,11 +128,13 @@ kustomize build --load-restrictor LoadRestrictionsNone infra/k8s/alpha/api/ | ku
 
 ### Sync with env templates
 
-ConfigMaps in `base/<component>/01-configmap.yaml` should mirror the structure of the authoritative app `.env.example` files (e.g. `apps/api/.env.example`, `apps/workers/.env.example`). Infra env-templates for apps are link-only stubs.
+ConfigMaps are generated from `base/<component>/source/*.env` via `configMapGenerator`. Keep keys
+aligned with authoritative app `.env.example` files (e.g. `apps/api/.env.example`,
+`apps/workers/.env.example`) and `infra/config/env-templates/*.env.example`.
 
 - Use same section headers (e.g., `##### App / General #####`)
 - Add comment: `# Mapped from apps/<component>/.env.example`
-- Keep variable names and structure aligned
+- **Unquoted values** in `source/*.env` (see **env-file-formatting** skill) — e.g. `DB_PORT=5432`
 
 ### Secrets Handling
 
@@ -242,6 +244,15 @@ sops -d secrets/podverse-alpha-db-opaque.enc.yaml | kubectl apply -f -
 - All secrets must be encrypted with SOPS before committing
 - `.gitignore` should exclude decrypted secret files
 - Scripts generate encrypted files automatically
+
+## Value types in YAML
+
+- **String schema fields:** double-quoted YAML strings are fine (Prettier default under `infra/k8s/`).
+- **Integer / float schema fields:** use unquoted numbers (`replicas: 1`, `containerPort: 3000`).
+  Never `"1"` or `"3000"` where OpenAPI expects a numeric type — strict validators reject that.
+- **`containers[].env[].value`:** always a string in the API; `value: "5432"` is valid for env data.
+
+See [.cursor/rules/infra-k8s.mdc](../../.cursor/rules/infra-k8s.mdc) § Value types in YAML.
 
 ## Linting and Formatting
 


### PR DESCRIPTION
- Revised the description and scope of the `.env` formatting rules to clarify the distinction between Node/Docker and K8s configurations.
- Enhanced documentation on value formatting, specifying double-quoted values for Node/Docker and unquoted values for K8s `source/*.env`.
- Updated examples and rationale sections to improve clarity and consistency in the documentation regarding environment variable handling.
- Added specific guidelines for comments and variable ordering in K8s ConfigMap files.