### PR TITLE
feat(navbar): add loading overlay for dashboard navigation

### DIFF
--- a/apps/management-web/e2e/navbar-chrome.spec.ts
+++ b/apps/management-web/e2e/navbar-chrome.spec.ts
@@ -35,4 +35,36 @@ test.describe('Management layout navbar chrome', () => {
       page.getByText(/Role:/)
     );
   });
+
+  test('clicking a dashboard nav card shows a loading overlay until the destination route is ready', async ({
+    page,
+  }, testInfo) => {
+    await page.goto('/');
+
+    await page.locator('#email').fill('e2e-superadmin@example.com');
+    await page.locator('#password').fill('Test!1Aa');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+
+    await page.waitForURL('**/dashboard');
+
+    const usersNavLink = page.getByRole('link', { name: 'Users' });
+    await expect(usersNavLink).toBeVisible();
+
+    const loadingOverlay = page.getByLabel('Loading…');
+
+    await Promise.all([
+      loadingOverlay.waitFor({ state: 'visible', timeout: 10_000 }),
+      usersNavLink.click(),
+    ]);
+
+    await page.waitForURL('**/users');
+    await expect(loadingOverlay).toBeHidden();
+
+    await capturePageLoad(
+      page,
+      testInfo,
+      'The users list page is visible after route navigation and the loading overlay is dismissed.',
+      page.getByRole('heading', { name: 'Users' })
+    );
+  });
 });

--- a/apps/management-web/src/components/LoadingSpinner/ManagementRouteNavigationLoading.tsx
+++ b/apps/management-web/src/components/LoadingSpinner/ManagementRouteNavigationLoading.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { RouteNavigationLoading } from '@podverse/ui';
+
+/**
+ * Global in-app route transition overlay for the management-web app.
+ */
+export function ManagementRouteNavigationLoading() {
+  const t = useTranslations('misc');
+  return <RouteNavigationLoading ariaLabel={t('loading')} />;
+}

--- a/apps/management-web/src/providers/Providers.tsx
+++ b/apps/management-web/src/providers/Providers.tsx
@@ -2,6 +2,9 @@
 
 import type { AbstractIntlMessages } from 'next-intl';
 import { NextIntlClientProvider } from 'next-intl';
+import { Suspense } from 'react';
+
+import { ManagementRouteNavigationLoading } from '../components/LoadingSpinner/ManagementRouteNavigationLoading';
 
 export default function Providers({
   children,
@@ -14,6 +17,9 @@ export default function Providers({
 }) {
   return (
     <NextIntlClientProvider locale={locale} messages={messages} timeZone="America/Chicago">
+      <Suspense fallback={null}>
+        <ManagementRouteNavigationLoading />
+      </Suspense>
       {children}
     </NextIntlClientProvider>
   );


### PR DESCRIPTION
- Implemented a new test to verify that clicking a dashboard navigation card displays a loading overlay until the destination route is fully loaded.
- Introduced a new component, ManagementRouteNavigationLoading, to serve as a global in-app route transition overlay.
- Wrapped the ManagementRouteNavigationLoading component in a Suspense fallback within the Providers component to handle loading states effectively.