### PR TITLE
refactor(build): update build scripts in package.json and add build-o…

### DIFF
--- a/.cursor/rules/build-order-doc-sync.mdc
+++ b/.cursor/rules/build-order-doc-sync.mdc
@@ -1,0 +1,24 @@
+---
+description: Keep build order dependency-safe and docs synced when build orchestration changes.
+globs:
+  - package.json
+  - scripts/ci/run-workspaces.mjs
+  - makefiles/local/Makefile.local.validate.mk
+  - .github/workflows/ci.yml
+alwaysApply: false
+---
+
+# Build order and docs sync
+
+Use the `build-order` skill (`.cursor/skills/build-order/SKILL.md`) whenever you edit build
+orchestration.
+
+## Required
+
+- Preserve dependency-safe staged build execution.
+- Keep root `build` aligned with package/app/tool build sequencing.
+- Update `docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md` when behavior changes.
+
+## Prohibited
+
+- Do not reintroduce all-workspace root build execution that can violate workspace dependency order.

--- a/.cursor/skills/abcmemory/SKILL.md
+++ b/.cursor/skills/abcmemory/SKILL.md
@@ -68,3 +68,13 @@ Use this table to choose where to **create or update** abcmemory:
 - Match existing repo style (frontmatter, skill `name` = folder name, blank line after closing `---`).
 - Keep changes minimal and focused on what the user asked to remember.
 - After abremembering, tell the user which abcmemory files were **created or updated** so they can commit them.
+
+## Build process + docs sync guardrail
+
+When build orchestration changes (`package.json` build scripts, CI validate sequencing, or workspace
+build runner behavior), abcremember requires updating build-order guidance in both:
+
+- `.cursor/skills/build-order/SKILL.md`
+- `docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md`
+
+Do not merge build-order changes that leave the canonical build-order document stale.

--- a/.cursor/skills/build-order/SKILL.md
+++ b/.cursor/skills/build-order/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: build-order
+description: Keep monorepo build order dependency-safe and keep build-order docs in sync when build orchestration changes.
+---
+
+# Build Order
+
+Use this skill when you change root build orchestration, workspace build sequencing, or CI/local
+validation flows that affect build execution order.
+
+## Canonical sequence
+
+From repo root, build in this order:
+
+1. `npm run build:packages`
+2. `npm run build:apps`
+3. `npm run build:tools`
+
+`npm run build` must preserve this staged order.
+
+## Why
+
+Package outputs (`dist/*.d.ts`) are required by downstream workspace builds. If order is broken,
+first-time builds can fail with `TS2307` module-resolution errors.
+
+## Keep in sync when build process changes
+
+When changing build order/process, update all relevant sources in the same PR:
+
+- `package.json` (`build`, `build:packages`, `build:apps`, `build:tools`)
+- `docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md`
+- Any workflow/docs summaries that would otherwise describe stale ordering
+
+## Do
+
+- Use explicit workspace ordering for dependency-sensitive package builds.
+- Keep root build orchestration readable and staged.
+- Update build-order docs whenever orchestration behavior changes.
+
+## Don't
+
+- Do not use all-workspace build enumeration for root `build` unless dependencies are guaranteed.
+- Do not change build sequencing without updating the canonical build-order doc.

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -17,6 +17,9 @@ npm run dev:api # Start API (localhost:3000)
 npm run dev:web # Start web app (localhost:3002)
 ```
 
+Build order details and dependency-safe sequencing are documented in
+[DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md](tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md).
+
 ## Workflow
 
 ### Starting a Feature

--- a/docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md
+++ b/docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md
@@ -1,0 +1,71 @@
+# Build Order Of Operations
+
+This document defines the required build order for first-time and clean builds in the Podverse
+monorepo.
+
+## Why order matters
+
+Many workspaces import other internal `@podverse/*` packages. If a dependent package builds before
+its dependency has emitted `dist/*.d.ts`, TypeScript reports module-resolution failures such as:
+
+- `TS2307: Cannot find module '@podverse/helpers'`
+- `TS2307: Cannot find module '@podverse/parser-mapping'`
+
+The root build flow must therefore run in dependency-safe stages.
+
+## Canonical root build sequence
+
+`npm run build` from repo root runs this exact order:
+
+1. `npm run build:packages`
+2. `npm run build:apps`
+3. `npm run build:tools`
+
+## Stage details
+
+### 1) Packages first
+
+`npm run build:packages` uses an explicit workspace order in `package.json` so foundational
+packages (for example `helpers`, `observability`, request helpers, ORM, parser) are built before
+dependents.
+
+### 2) Apps and sidecars second
+
+`npm run build:apps` builds:
+
+- `apps/api`
+- `apps/web`
+- `apps/workers`
+- `apps/management-api`
+- `apps/management-web`
+- `apps/web/sidecar`
+- `apps/management-web/sidecar`
+
+### 3) Tools last
+
+`npm run build:tools` builds:
+
+- `tools/qa`
+- `tools/test-assets`
+
+These depend on already-built package outputs and should not run before packages/apps are ready.
+
+## Commands
+
+```bash
+npm run build
+npm run build:packages
+npm run build:apps
+npm run build:tools
+```
+
+## When changing build process
+
+If you modify build orchestration, keep order-of-operations correct and update these files in the
+same change:
+
+- `package.json` (`build`, `build:packages`, `build:apps`, `build:tools`)
+- `docs/development/tooling/DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md` (this document)
+- Any related CI/validation flow summaries if behavior changed
+
+Do not switch root `build` back to all-workspace enumeration without dependency-safe staging.

--- a/package.json
+++ b/package.json
@@ -60,10 +60,11 @@
   "scripts": {
     "prepare": "bash scripts/git-hooks/install-hooks.sh",
     "start-feature": "bash scripts/start-feature.sh",
-    "build": "node scripts/ci/run-workspaces.mjs --script build --all",
+    "build": "npm run build:packages && npm run build:apps && npm run build:tools",
     "build:packages": "node scripts/ci/run-workspaces.mjs --script build --workspaces packages/worker-commands packages/helpers packages/observability packages/extension-metrics-sdk packages/integrations-web packages/helpers-validation packages/v4v-metaboost packages/v4v-helpers packages/parser-mapping packages/http-request-core packages/helpers-requests packages/management-api-requests packages/helpers-backend packages/helpers-browser packages/helpers-config packages/external-services-firebase packages/external-services-paypal packages/external-services-object-storage packages/external-services-podcast-index packages/orm packages/notifications packages/parser packages/mq packages/v4v-btc-ln",
     "build:packages:prod": "node scripts/ci/run-workspaces.mjs --script build:prod --workspaces packages/worker-commands packages/helpers packages/observability packages/extension-metrics-sdk packages/integrations-web packages/helpers-validation packages/v4v-metaboost packages/v4v-helpers packages/parser-mapping packages/http-request-core packages/helpers-requests packages/management-api-requests packages/helpers-backend packages/helpers-browser packages/helpers-config packages/external-services-firebase packages/external-services-paypal packages/external-services-object-storage packages/external-services-podcast-index packages/orm packages/notifications packages/parser packages/mq packages/v4v-btc-ln",
     "build:apps": "node scripts/ci/run-workspaces.mjs --script build --workspaces apps/api apps/web apps/workers apps/management-api apps/management-web apps/web/sidecar apps/management-web/sidecar",
+    "build:tools": "node scripts/ci/run-workspaces.mjs --script build --workspaces tools/qa tools/test-assets",
     "clean": "npm run clean --workspaces --if-present",
     "clean:packages": "find packages -name 'tsconfig.tsbuildinfo' -delete && find packages -type d -name 'dist' -exec rm -rf {} + 2>/dev/null || true",
     "clean:apps": "find apps -name 'tsconfig.tsbuildinfo' -delete && find apps -type d \\( -name 'dist' -o -name '.next' -o -name '.cache' -o -name 'compiled' \\) -exec rm -rf {} + 2>/dev/null || true",


### PR DESCRIPTION
…rder documentation

- Modified the `build` script in package.json to call individual build scripts for packages, apps, and tools.
- Introduced a new `build-order-doc-sync.mdc` file to ensure build order dependencies are maintained and documented.
- Created a new `build-order` skill to guide updates related to build orchestration changes.
- Added detailed documentation on build order operations in `DOCS-DEVELOPMENT-TOOLING-BUILD-ORDER.md` to clarify the required sequence for builds.
- Updated CONTRIBUTING.md to reference the new build order documentation.