### PR TITLE
Bug/shrink image00

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {

--- a/infra/k8s/base/cron/worker-image-shrink-source-prune.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-image-shrink-source-prune.cronjob.yaml
@@ -38,6 +38,8 @@ spec:
                 - secretRef:
                     name: podverse-db-opaque
                 - secretRef:
+                    name: podverse-mq-opaque
+                - secretRef:
                     name: podverse-workers-add-by-rss-opaque
                 - secretRef:
                     name: podverse-workers-webpush-opaque

--- a/packages/orm/src/services/imageShrinkSource.ts
+++ b/packages/orm/src/services/imageShrinkSource.ts
@@ -105,9 +105,9 @@ export class ImageShrinkSourceService {
       AND (
         source.last_changed_at IS NOT NULL
         OR (
-          $1 IS NOT NULL
+          $1::integer IS NOT NULL
           AND source.last_checked_at IS NOT NULL
-          AND source.last_checked_at < NOW() - ($1 * interval '1 second')
+          AND source.last_checked_at < NOW() - ($1::integer * interval '1 second')
         )
       )
       RETURNING 1;


### PR DESCRIPTION
## Summary

Fixes `worker-image-shrink-source-prune` CronJob crash looping with two issues:

1. **Missing `podverse-mq-opaque`** in the CronJob manifest's `envFrom`
2. **PostgreSQL type inference failure** in `deleteUnusedSources` raw SQL query

## Changes

### `infra/k8s/base/cron/worker-image-shrink-source-prune.cronjob.yaml`

Added `podverse-mq-opaque` secret ref to `envFrom`, matching the pattern used by all other cron jobs including `worker-image-shrink-orphan-cleanup` and `worker-image-shrink-backfill`.

### `packages/orm/src/services/imageShrinkSource.ts`

Added `::integer` type casts to parameter `$1` in the raw SQL query inside `deleteUnusedSources()`. Without explicit casts, PostgreSQL cannot determine the parameter type when `$1` first appears in `$1 IS NOT NULL` (no column context for type inference), causing:

```
could not determine data type of parameter $1 - QueryFailedError
```

## Testing

- [x] `kustomize build` produces correct CronJob manifest with `podverse-mq-opaque` included
- [x] Manual test job runs successfully — connects to DB, executes `imageShrinkSourcePrune`, and completes normally
