### PR TITLE
infra(cron): set backoffLimit=0 and restartPolicy=Never on all worker…

### DIFF
--- a/infra/k8s/base/cron/worker-archive-all.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-archive-all.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "0 6,18 * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -58,4 +64,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-billing-renewals.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-billing-renewals.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -50,4 +56,4 @@ spec:
           volumes:
             - name: logs-volume
               emptyDir: {}
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-dead-feeds-merge.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-dead-feeds-merge.cronjob.yaml
@@ -9,8 +9,14 @@ spec:
   suspend: true
   schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -69,4 +75,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-delete-outdated.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-delete-outdated.cronjob.yaml
@@ -9,6 +9,11 @@ spec:
   failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -63,4 +68,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-generate-reports.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-generate-reports.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -61,4 +67,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-image-shrink-backfill.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-image-shrink-backfill.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -61,4 +67,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-image-shrink-orphan-cleanup.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-image-shrink-orphan-cleanup.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "0 3 * * 0"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -61,4 +67,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-image-shrink-source-prune.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-image-shrink-source-prune.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "0 4 * * 0"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -59,4 +65,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/infra/k8s/base/cron/worker-recent-feeds.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-recent-feeds.cronjob.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 10
   jobTemplate:
     spec:
+      # Single attempt per cron tick: the cron schedule is the retry
+      # mechanism. In-place container restarts (restartPolicy: OnFailure
+      # + default backoffLimit: 6) turn a transient upstream 5xx into
+      # CrashLoopBackOff alerts. See <link-to-be-filed>.
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -65,4 +71,4 @@ spec:
               secret:
                 secretName: podverse-workers-firebase-opaque
                 optional: true
-          restartPolicy: OnFailure
+          restartPolicy: Never


### PR DESCRIPTION
… CronJobs

All nine CronJobs in infra/k8s/base/cron/ are single-shot idempotent recurring work scheduled by cron. The default Kubernetes behavior (restartPolicy: OnFailure + backoffLimit: 6) layers in-place kubelet restarts on top of Job-controller retries on top of the cron schedule itself — three retry layers stacked on a job that already retries on its own schedule. For these workloads, the inner two layers add no real recovery value and actively cause CrashLoopBackOff alerts on transient upstream failures.

- Set backoffLimit: 0 on every CronJob — one attempt per cron tick; the schedule itself is the retry mechanism.
- Set restartPolicy: Never on every pod template — eliminates the CrashLoopBackOff failure mode entirely.
- Standardize failedJobsHistoryLimit: 10 across all CronJobs (it was already 10 on worker-delete-outdated; everywhere else it defaulted to 1). With a single attempt per tick, operators benefit from seeing a longer window of recent failures rather than just the latest one.
- Add an explanatory comment above each backoffLimit so the rationale survives in 'git blame' and discourages well-meaning reverts.

This is a strict-subset behavior change: one attempt instead of up to seven. No execution that previously succeeded will now fail.

Verified end-to-end on a downstream cluster running these manifests: the previous CrashLoopBackOff response to a transient PodcastIndex 500 becomes a single Failed Job with restartCount=0 and no BackOff event.

This is the manifest-level defense in depth; the real fix is to teach the worker code to distinguish recoverable upstream errors (5xx, 408, 429, network errors) from real failures and exit 0 on the former. See the linked issue for that follow-up.

## Description

<!-- What does this PR do? -->

## Related Issue

<!-- Link to GitHub issue: Fixes #123 or Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code compiles without errors
- [ ] Linting passes (`npm run lint`)
- [ ] I have tested my changes
- [ ] Documentation updated if needed

## OpenAPI Evidence (Required For Route/Contract/Auth Changes)

If this PR changes API route behavior, auth semantics, validators, or request/response contracts, complete all items below. Missing evidence is a merge blocker.

- [ ] I ran `./scripts/nix/with-env npm run openapi:check` and pasted the result summary below
- [ ] I mapped each changed route to OpenAPI path+method+operationId below
- [ ] I documented 401 vs 403 behavior notes for changed protected endpoints below
- [ ] If no spec edit was required for a route-related change, I included explicit justification below

### OpenAPI Check Result

<!-- Paste validator/lint/bundle summary -->

### Route Parity Mapping

<!-- source route -> OpenAPI path/method -> operationId -->

### Auth Notes (401 vs 403)

<!-- Required for changed protected endpoints -->

### No-Spec-Change Justification

<!-- Required only when route behavior changed but no spec files were edited -->

## LLM Development (Optional)

If you maintain optional notes under `.llm/history/`, see [.llm/LLM.md](.llm/LLM.md). When a PR merges to `develop`, a workflow may archive matching feature folders under `.llm/history/active/` to `.llm/history/completed/`.

## CI

> **Note**: A maintainer will comment `/test` to run CI checks on this PR.

> **OpenAPI policy**: For route/contract/auth changes, OpenAPI evidence above is required before merge.

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
