### PR TITLE
fix(scripts): unblock npm ci in Docker worktree mounts; standardize shebangs

### DIFF
--- a/scripts/audit/audit.sh
+++ b/scripts/audit/audit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check for vulnerabilities in all packages.
 # By default, only moderate and above fail (low are permitted in deployments).
 # Pass --include-low to also fail on low vulnerabilities (report and fix on demand).

--- a/scripts/cleanup-validation-imports.sh
+++ b/scripts/cleanup-validation-imports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to remove unused validation imports from web app files
 # Only removes the import if the file doesn't actually use the validation functions

--- a/scripts/dev/setup.sh
+++ b/scripts/dev/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Podverse Development Setup
 # Run from monorepo root
 

--- a/scripts/development/update-lockfile-linux.sh
+++ b/scripts/development/update-lockfile-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regenerate package-lock.json under Linux (Docker) so optional deps match CI.
 # Run from repo root when adding/updating deps or as part of bump-version.
 # Requires: Docker.

--- a/scripts/fix-query-imports.sh
+++ b/scripts/fix-query-imports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to fix QueryParams imports - move them from @podverse/helpers to @podverse/helpers-requests
 # EXCEPT QueryParamsMedium and QueryParamsQueueMedium which stay in @podverse/helpers

--- a/scripts/git-hooks/install-hooks.sh
+++ b/scripts/git-hooks/install-hooks.sh
@@ -1,10 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-# Worktrees use a .git file; hooks live in the main repo's .git/hooks (shared).
-HOOKS_DIR="$(git -C "$REPO_ROOT" rev-parse --git-path hooks)"
+
+# Skip silently when there is no usable git context (e.g. Docker mounts of a
+# worktree without the linked .git dir, tarball installs, some CI sandboxes).
+# Hooks are a developer convenience and must never block `npm ci`.
+if ! HOOKS_DIR="$(git -C "$REPO_ROOT" rev-parse --git-path hooks 2>/dev/null)"; then
+  echo "Skipping git hooks install: no usable git working tree at $REPO_ROOT."
+  exit 0
+fi
+
+# `git rev-parse --git-path` may return a relative path; normalize to absolute.
+case "$HOOKS_DIR" in
+  /*) ;;
+  *) HOOKS_DIR="$REPO_ROOT/$HOOKS_DIR" ;;
+esac
 
 echo "Installing git hooks..."
 mkdir -p "$HOOKS_DIR"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Podverse Pre-Push Hook - Branch Naming Enforcement
 # Outputs to stderr so messages appear in GUI error dialogs

--- a/scripts/github/setup-all-labels.sh
+++ b/scripts/github/setup-all-labels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # GitHub labels setup – Podverse repository
 # Creates or updates all labels. Idempotent: run multiple times safely.
 # Optionally prompts to delete repo labels that are not in the script (does not

--- a/scripts/lib/check-audit-gate.sh
+++ b/scripts/lib/check-audit-gate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Shared npm audit gate with allowlist support
 # Centralizes audit validation logic across release scripts to maintain consistency
 # Usage: scripts/lib/check-audit-gate.sh <allowed-ids> [context-name]

--- a/scripts/management/create-superuser.sh
+++ b/scripts/management/create-superuser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/management/update-superuser.sh
+++ b/scripts/management/update-superuser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/podcast-index/get-feed-url-dump.sh
+++ b/scripts/podcast-index/get-feed-url-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [ -z "${1}" ] && exit 1
 

--- a/scripts/publish/bump-version.sh
+++ b/scripts/publish/bump-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Bump version across all packages
 # Uses --no-verify to bypass git hooks
 # Requires branch protection bypass permissions in GitHub for the user

--- a/scripts/publish/sync-develop-to-staging.sh
+++ b/scripts/publish/sync-develop-to-staging.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Fast-forward `staging` to match `develop` (triggers the Publish (staging) workflow on push).
 
 set -e

--- a/scripts/publish/sync-staging-to-main.sh
+++ b/scripts/publish/sync-staging-to-main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Fast-forward `main` to match `staging` (triggers Publish (main) — promote-only, no app rebuild).
 # Intended flow: sync develop -> staging (build in GH), then this script: staging -> main (RTM).
 # Do not use develop -> main; `main` should only advance from the pre-built staging line.

--- a/scripts/start-feature.sh
+++ b/scripts/start-feature.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Podverse Start Feature Script
 # Creates a properly named git branch (optional LLM history scaffold disabled; see docs/development/llm/LLM-HISTORY-WORKFLOW-ARCHIVE.md)


### PR DESCRIPTION
## Summary

- Fix `npm ci` failure (exit code 128) when run inside a Docker container that bind-mounts a git worktree (e.g. `scripts/publish/sync-develop-to-staging.sh`).
- Standardize `scripts/` shebangs to `#!/usr/bin/env bash` (15 files); aligns with the 35 scripts in `scripts/` that already use it and is portable across Nix shells.

## Why

Running `bash ./scripts/publish/sync-develop-to-staging.sh` from a worktree failed inside Docker because the worktree's `.git` file points to `/home/.../podverse/.git/worktrees/<name>` which is not mounted into the container. The root `prepare` script (`bash scripts/git-hooks/install-hooks.sh`) then ran `git rev-parse --git-path hooks` which failed, aborting `npm ci` before the audit gate could even run.

Hooks are a pure developer convenience — they must never block `npm ci`.

Observed failure:

```
fatal: not a git repository: /home/brentano/wip/github.com/podverse/podverse/.git/worktrees/develop
npm error code 128
npm error path /app
npm error command failed
npm error command sh -c bash scripts/git-hooks/install-hooks.sh
Error: npm ci or npm audit gate failed in Docker. Fix issues before syncing to staging.
```

## Changes

### Commit 1 — `scripts/git-hooks/install-hooks.sh`

- Guard `git rev-parse --git-path hooks` and skip with a clear message when no usable git working tree is reachable.
- Normalize relative paths returned by `git rev-parse --git-path` to absolute.
- Flip shebang to `#!/usr/bin/env bash` (included in the fix commit so this file is internally consistent with the sweep).

### Commit 2 — `chore(scripts): standardize shebang` (15 files)

First-line-only change `#!/bin/bash` → `#!/usr/bin/env bash` in:

- `scripts/audit/audit.sh`
- `scripts/cleanup-validation-imports.sh`
- `scripts/dev/setup.sh`
- `scripts/development/update-lockfile-linux.sh`
- `scripts/fix-query-imports.sh`
- `scripts/git-hooks/pre-push`
- `scripts/github/setup-all-labels.sh`
- `scripts/lib/check-audit-gate.sh`
- `scripts/management/create-superuser.sh`
- `scripts/management/update-superuser.sh`
- `scripts/podcast-index/get-feed-url-dump.sh`
- `scripts/publish/bump-version.sh`
- `scripts/publish/sync-develop-to-staging.sh`
- `scripts/publish/sync-staging-to-main.sh`
- `scripts/start-feature.sh`

## Compatibility

`#!/usr/bin/env bash` is functionally identical to `#!/bin/bash` on all targeted platforms. `/usr/bin/env` is universally present (Linux Docker, GHA ubuntu runners, macOS, NixOS / nix-darwin).

## Behavior matrix

| Environment                              | Before              | After                       |
| ---------------------------------------- | ------------------- | --------------------------- |
| Plain checkout (host) — `npm ci`         | Installs hooks      | Installs hooks (same)       |
| Worktree (host) — `npm ci`               | Installs to shared  | Installs to shared (same)   |
| Docker mount of worktree — `npm ci`      | exit 128 (fails)    | Skips with notice; proceeds |
| CI checkout                              | Installs hooks      | Installs hooks (same)       |
| No `.git` at all                         | exit 128 (fails)    | Skips with notice           |

## Verification

Performed locally on the host worktree (with packages built first):

```bash
./scripts/nix/with-env npm ci             # prepare runs install-hooks.sh successfully
./scripts/nix/with-env npm run build:packages
./scripts/nix/with-env npm run lint
# --- Lint summary ---
# Type-check: passed
# Lint:      passed
# Prettier:  passed
```

Reviewers can repro the original failing case in Docker (audit gate may pass or fail on actual advisories; the point is that `npm ci` no longer aborts at code 128):

```bash
docker run --rm --platform linux/amd64 \
  -v "$PWD:/app" -w /app node:24 \
  bash -c 'npm ci && bash scripts/lib/check-audit-gate.sh "1117015" "promote to staging"'
```

## Out of scope

- Shebangs under `infra/`, `apps/`, `extensions/`, `packages/`.
- Any Docker / mount strategy or audit allowlist changes in `scripts/publish/sync-develop-to-staging.sh`.
