### PR TITLE
fix(k8s): mount add-by-rss secret on billing renewals cron

### DIFF
--- a/infra/k8s/base/cron/worker-billing-renewals.cronjob.yaml
+++ b/infra/k8s/base/cron/worker-billing-renewals.cronjob.yaml
@@ -46,6 +46,8 @@ spec:
                 - secretRef:
                     name: podverse-mq-opaque
                 - secretRef:
+                    name: podverse-workers-add-by-rss-opaque
+                - secretRef:
                     name: podverse-workers-webpush-opaque
                     optional: true
               volumeMounts:


### PR DESCRIPTION
## Summary
- Add `podverse-workers-add-by-rss-opaque` secretRef to `worker-billing-renewals` CronJob
- Matches other cron jobs; fixes FATAL startup when `ADD_BY_RSS_CREDENTIALS_ENCRYPTION_KEY` is missing

## Test plan
- [ ] After publish, sync podverse-alpha-cron and confirm billing renewals job passes validation

Made with [Cursor](https://cursor.com)